### PR TITLE
Reset button text to empty string to align button icon

### DIFF
--- a/downloadaudio/download.py
+++ b/downloadaudio/download.py
@@ -217,6 +217,7 @@ def editor_add_download_editing_button(self):
         tip=u"Download audio...", text=" ")
     dl_button.setIcon(
         QIcon(os.path.join(icons_dir, 'download_note_audio.png')))
+    dl_button.setText("")
 
 
 # Either reuse an edit-media sub-menu created by another add-on


### PR DESCRIPTION
After calling _addButton with the button text set to a white space,
it must be set to an empty string in order to make the button icon
center aligned