### PR TITLE
allow to have different display text

### DIFF
--- a/downloadaudio/download.py
+++ b/downloadaudio/download.py
@@ -86,16 +86,14 @@ def do_download(note, field_data, language, hide_text=False):
                 ## downloaders list in downloaders.__init__
                 # raise
                 continue
-            show_skull_and_bones = \
-                show_skull_and_bones or dloader.show_skull_and_bones
-            for word_path, file_name, extras in dloader.downloads_list:
+            for entry in dloader.downloads_list:
                 try:
-                    item_hash = get_hash(word_path)
+                    item_hash = get_hash(entry.word_file_path)
                 except ValueError:
                     # Now the downloader downloads, doesn't remove
                     # files with bad hashes. So do it here.
                     # print 'bad hash'
-                    os.remove(word_path)
+                    os.remove(entry.word_file_path)
                     continue
                 if processor.useful:
                     # if not processor.useful we write directly to the
@@ -105,17 +103,19 @@ def do_download(note, field_data, language, hide_text=False):
                         # downloader downloads to a temp file, so move
                         # here.
                         file_name = processor.process_and_move(
-                            word_path, dloader.base_name)
+                            entry.word_file_path, entry.base_name)
                     except:
                         # raise  # Use this to debug an audio processor.
-                        os.remove(word_path)
+                        os.remove(entry.word_file_path)
                         continue
-                # else:
-                #    file_name = file_name
+                else:
+                    file_name = entry.word_file_name
+                show_skull_and_bones = \
+                    show_skull_and_bones or entry.show_skull_and_bones
                 # We pass the file name around for this case.
                 retrieved_files_list.append((
-                    source, dest, dloader.display_text,
-                    file_name, item_hash, extras, dloader.site_icon))
+                    source, dest, entry.display_text,
+                    file_name, item_hash, entry.extras, dloader.site_icon))
     try:
         store_or_blacklist(
             note, retrieved_files_list, show_skull_and_bones, hide_text)

--- a/downloadaudio/download_entry.py
+++ b/downloadaudio/download_entry.py
@@ -6,8 +6,8 @@
 
 class DownloadEntry(object):
     def __init__(self, word_file_path, word_file_name, base_name, display_text,
-                 file_extension = u'.wav', extras = {},
-                 show_skull_and_bones = False):
+                 file_extension=u'.wav', extras={},
+                 show_skull_and_bones=False):
         self.word_file_path = word_file_path
         """Absolute file path of the downloaded audio file"""
         self.word_file_name = word_file_name
@@ -21,7 +21,9 @@ class DownloadEntry(object):
         self.file_extension = file_extension
         """The file extension (with dot)"""
         self.extras = extras
-        """Dictionary with extra information shown in the tooltip"""
+        """A dict with strings of interesting informations, like
+        meaning numbers or name of speaker, or an empty dict.
+        (shown in the tooltip)"""
         self.show_skull_and_bones = show_skull_and_bones
         """
         Should we show the skull and crossbones in the review dialog?

--- a/downloadaudio/download_entry.py
+++ b/downloadaudio/download_entry.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- mode: python ; coding: utf-8 -*-
+#
+# License: GNU AGPL, version 3 or later;
+# http://www.gnu.org/copyleft/agpl.html
+
+class DownloadEntry(object):
+    def __init__(self, word_file_path, word_file_name, base_name, display_text,
+                 file_extension = u'.wav', extras = {},
+                 show_skull_and_bones = False):
+        self.word_file_path = word_file_path
+        """Absolute file path of the downloaded audio file"""
+        self.word_file_name = word_file_name
+        """The file name of the downloaded audio file (the
+        last component of word_file_path"""
+        self.base_name = u''
+        """What you want the base name of the file to be when moved to the
+        media directory. (without file extension)"""
+        self.display_text = display_text
+        """Text shown as source after download"""
+        self.file_extension = file_extension
+        """The file extension (with dot)"""
+        self.extras = extras
+        """Dictionary with extra information shown in the tooltip"""
+        self.show_skull_and_bones = show_skull_and_bones
+        """
+        Should we show the skull and crossbones in the review dialog?
+
+        Normal downloaders should leave this alone. The point of the
+        whole blacklist mechanism is that JapanesePod can't say
+        no. Only when there is a chance that we have a file we want to
+        blacklist (that is, when we actually downloaded something from
+        Japanesepod) should we set this to True.
+        """
+
+

--- a/downloadaudio/downloaders/collins.py
+++ b/downloadaudio/downloaders/collins.py
@@ -8,11 +8,14 @@
 
 """
 Download pronunciations from Merriam-Webster.
+
+Abstract base class, derived for several languages.
 """
 
 import urllib
 
 from .downloader import AudioDownloader, uniqify_list
+from ..download_entry import DownloadEntry
 
 
 class CollinsDownloader(AudioDownloader):
@@ -41,7 +44,6 @@ class CollinsDownloader(AudioDownloader):
         if split:
             # Avoid double downloads
             return
-        self.set_names(word, base, ruby)
         if not self.language.lower().startswith(self.lang):
             return
         if not word:
@@ -79,11 +81,13 @@ class CollinsDownloader(AudioDownloader):
         self.maybe_get_icon()
         for lnk in link_list:
             word_data = self.get_data_from_url(lnk)
-            word_path, word_fname = self.get_file_name()
+            word_path, word_fname = self.get_file_name(
+                word, self.file_extension)
             with open(word_path, 'wb') as word_file:
                 word_file.write(word_data)
-            self.downloads_list.append(
-                (word_path, word_fname, self.extras))
+            self.downloads_list.append(DownloadEntry(
+                word_path, word_fname, base_name=word, display_text=word,
+                file_extension=self.file_extension, extras=self.extras))
 
     def get_link(self, onclick_string):
         # Wrote these bits for ooad

--- a/downloadaudio/downloaders/downloader.py
+++ b/downloadaudio/downloaders/downloader.py
@@ -54,13 +54,8 @@ class AudioDownloader(object):
         Store for downloaded data.
 
         This is where self.download_files should store the
-        results. See that method's docstring.
+        results (type DownloadEntry).
         """
-        self.display_text = u''
-        """Text shown as source after download"""
-        self.base_name = u''
-        """Base of the final file name."""
-        self.file_extension = u'.wav'
         # A typical downloaders will need something like this.
         self.url = ''
         """The base URL used for (the first step of) the download."""
@@ -95,16 +90,6 @@ class AudioDownloader(object):
         (and self.use_temp_files == False)
         we use the current directory.
         """
-        self.show_skull_and_bones = False
-        """
-        Should we show the skull and crossbones in the review dialog?
-
-        Normal downloaders should leave this alone. The point of the
-        whole blacklist mechanism is that JapanesePod can't say
-        no. Only when there is a chance that we have a file we want to
-        blacklist (that is, when we actually downloaded something from
-        Japanesepod) should we set this to True.
-        """
 
         self.site_icon = None
         """The sites's favicon."""
@@ -130,20 +115,6 @@ class AudioDownloader(object):
         meaning numbers or name of speaker, or an empty dict.
         """
         raise NotImplementedError("Use a class derived from this.")
-
-    def set_names(self, text, dummy_base, dummy_ruby):
-        """
-        Set the display text and file base name variables.
-
-        Set self.display_text and self.base_name with the text used
-        for download, formated in a form useful for display and for a
-        file name, respectively.
-        This version uses just the text. It should be reimplemented
-        for Japanese (Chinese, ...)  downloaders that use the base and
-        ruby.
-        """
-        self.base_name = text
-        self.display_text = text
 
     def maybe_get_icon(self):
         """
@@ -255,7 +226,7 @@ class AudioDownloader(object):
         """
         return soup(self.get_data_from_url(url_in))
 
-    def get_file_name(self):
+    def get_file_name(self, base_name, file_extension):
         """
         Get a free file name.
 
@@ -265,7 +236,7 @@ class AudioDownloader(object):
         """
         if self.use_temp_files:
             tfile = tempfile.NamedTemporaryFile(
-                delete=False, suffix=self.file_extension)
+                delete=False, suffix=file_extension)
             tfile.close()
             # Hack, free_media_name returns full path and file name,
             # so return two files here as well. But there is no real
@@ -279,4 +250,4 @@ class AudioDownloader(object):
             # which are imported by ..exists.
             from ..exists import free_media_name
             return free_media_name(
-                self.base_name, self.file_extension)
+                base_name, file_extension)

--- a/downloadaudio/downloaders/downloader.py
+++ b/downloadaudio/downloaders/downloader.py
@@ -105,14 +105,11 @@ class AudioDownloader(object):
         whole text (for most languages) or split into kanji and kana,
         base and ruby.
 
-        This function should clear the self.downloads_list, call
-        self.set_names(), and try to get pronunciation files from its
-        source, put those into tempfiles, and add a (temp_file_path,
-        base_name, extras) 3-tuple to self_downloads_lists for each of
+        This function should clear the self.downloads_list and try to
+        get pronunciation files from its source, put those into tempfiles,
+        and add a DownloadEntry object to self_downloads_lists for each of
         the zero or more downloaded files. (Zero when the
-        self.language is wrong, there is no file, ...) extras should
-        be a dict with strings of interesting informations, like
-        meaning numbers or name of speaker, or an empty dict.
+        self.language is wrong, there is no file, ...)
         """
         raise NotImplementedError("Use a class derived from this.")
 

--- a/downloadaudio/downloaders/duden.py
+++ b/downloadaudio/downloaders/duden.py
@@ -15,6 +15,7 @@ import unicodedata
 import urlparse
 
 from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
 
 transliterations = [(u'Ä', 'Ae'), (u'Ö', 'Oe'), (u'Ü', 'Ue'), (u'ä', 'ae'),
                     (u'ö', 'oe'), (u'ü', 'ue'), (u'ß', 'sz')]
@@ -54,7 +55,6 @@ class DudenDownloader(AudioDownloader):
         if split:
             # Avoid double downloads.
             return
-        self.set_names(word, base, ruby)
         if not self.language.lower().startswith('de'):
             return
         if not word:
@@ -76,11 +76,13 @@ class DudenDownloader(AudioDownloader):
                     # 'NoneType' object has no attribute 'group' ...
                     pass
                 word_data = self.get_data_from_url(link['href'])
-                word_path, word_fname = self.get_file_name()
+                word_path, word_fname = self.get_file_name(
+                    word, self.file_extension)
                 with open(word_path, 'wb') as word_file:
                     word_file.write(word_data)
-                self.downloads_list.append(
-                    (word_path, word_fname, extras))
+                self.downloads_list.append(DownloadEntry(
+                    word_path, word_fname, base_name=word, display_text=word,
+                    file_extension=self.file_extension, extras=extras))
 
     def good_link(self, link):
         """Check if link looks """

--- a/downloadaudio/downloaders/google_tts.py
+++ b/downloadaudio/downloaders/google_tts.py
@@ -13,6 +13,7 @@ Download pronunciations from GoogleTTS
 import urllib
 
 from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
 
 get_chinese = False
 """
@@ -44,16 +45,18 @@ class GooglettsDownloader(AudioDownloader):
             if not get_chinese:
                 return
             word = base
-        self.set_names(word, base, ruby)
         if not word:
             raise ValueError('Nothing to download')
         word_data = self.get_data_from_url(self.build_url(word))
-        word_path, word_file_name = self.get_file_name()
+        word_path, word_file_name = self.get_file_name(
+            word, self.file_extension)
         with open(word_path, 'wb') as word_file:
             word_file.write(word_data)
         # We have a file, but not much to say about it.
-        self.downloads_list.append(
-            (word_path, word_file_name, dict(Source='GoogleTTS')))
+        self.downloads_list.append(DownloadEntry(
+            word_path, word_file_name, base_name=word, display_text=word,
+            file_extension=self.file_extension,
+            extras=dict(Source='GoogleTTS')))
 
     def build_url(self, source):
         u"""Return a string that can be used as the url."""

--- a/downloadaudio/downloaders/howjsay.py
+++ b/downloadaudio/downloaders/howjsay.py
@@ -13,6 +13,7 @@ Download pronunciations from HowJSay.
 import urllib
 
 from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
 
 
 class HowJSayDownloader(AudioDownloader):
@@ -29,19 +30,19 @@ class HowJSayDownloader(AudioDownloader):
         if split:
             # Avoid double downloads
             return
-        self.set_names(word, base, ruby)
         if not self.language.lower().startswith('en'):
             return
         if not word:
             return
         # Replace special characters with ISO-8859-1 oct codes
-        extras = dict(Source="HowJSay")
         self.maybe_get_icon()
         audio_url = self.url + urllib.quote(word.encode('utf-8')) \
             + self.file_extension
         word_data = self.get_data_from_url(audio_url)
-        word_file_path, word_file_name = self.get_file_name()
+        word_file_path, word_file_name = self.get_file_name(
+            word, self.file_extension)
         with open(word_file_path, 'wb') as word_file:
             word_file.write(word_data)
-        self.downloads_list.append(
-            (word_file_path, word_file_name, extras))
+        self.downloads_list.append(DownloadEntry(
+            word_file_path, word_file_name, base_name=word, display_text=word,
+            file_extension=self.file_extension, extras=dict(Source="HowJSay")))

--- a/downloadaudio/downloaders/japanesepod.py
+++ b/downloadaudio/downloaders/japanesepod.py
@@ -52,8 +52,8 @@ Gecko/20100101 Firefox/15.0.1'''
         # Reason why we don't just do the get_data_.. bit inside the
         # with: Like this we don't have to clean up the temp file.
         word_data = self.get_data_from_url(self.query_url(base, ruby))
-        word_file_path, word_file_name = self.get_file_name(base_name,
-                                                            file_extension)
+        word_file_path, word_file_name = self.get_file_name(
+            base_name, file_extension)
         with open(word_file_path, 'wb') as word_file:
             word_file.write(word_data)
         # We have a file, but not much to say about it.

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -17,6 +17,7 @@ download_file_extension = u'.mp3'
 
 
 from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
 
 transliterations = [
     (u'å', '0345'), (u'ä', '0344'), (u'ö', '0366'), (u'é', '0351'),
@@ -56,19 +57,19 @@ class LexinDownloader(AudioDownloader):
         if split:
             # Avoid double downloads
             return
-        self.set_names(word, base, ruby)
         if not self.language.lower().startswith('sv'):
             return
         if not word:
             return
         # Replace special characters with ISO-8859-1 oct codes
         m_word = munge_word(word)
-        extras = dict(Source="Lexin")
         self.maybe_get_icon()
         audio_url = self.url + m_word + self.file_extension
         word_data = self.get_data_from_url(audio_url)
-        word_file_path, word_file_name = self.get_file_name()
+        word_file_path, word_file_name = self.get_file_name(
+            word, self.file_extension)
         with open(word_file_path, 'wb') as word_file:
             word_file.write(word_data)
-        self.downloads_list.append(
-            (word_file_path, word_file_name, extras))
+        self.downloads_list.append(DownloadEntry(
+            word_file_path, word_file_name, base_name=word, display_text=word,
+            file_extension=self.file_extension, extras=dict(Source="Lexin")))

--- a/downloadaudio/downloaders/macmillan.py
+++ b/downloadaudio/downloaders/macmillan.py
@@ -8,6 +8,8 @@
 
 """
 Download pronunciations from  Macmillan Dictionary.
+
+Abstract base class, derived for American and British English.
 """
 
 from copy import copy
@@ -15,6 +17,7 @@ import re
 import urllib
 
 from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
 
 # Work-around for broken BeautifulSoup
 sound_class = re.compile(r'\bsound\b')
@@ -40,7 +43,6 @@ class MacmillanDownloader(AudioDownloader):
         if split:
             # Avoid double downloads
             return
-        self.set_names(word, base, ruby)
         if not self.language.lower().startswith('en'):
             return
         if not word:
@@ -59,7 +61,8 @@ class MacmillanDownloader(AudioDownloader):
                 continue
             word_data = self.get_data_from_url(audio_url)
 
-            word_file_path, word_file_name = self.get_file_name()
+            word_file_path, word_file_name = self.get_file_name(
+                word, self.file_extension)
             with open(word_file_path, 'wb') as word_file:
                 word_file.write(word_data)
             extras = self.extras
@@ -71,5 +74,7 @@ class MacmillanDownloader(AudioDownloader):
                 if not 'pronunciation' in alt_string.lower():
                     extras = copy(self.extras)
                     extras['Alt text'] = alt_string
-            self.downloads_list.append(
-                (word_file_path, word_file_name, extras))
+            self.downloads_list.append(DownloadEntry(
+                word_file_path, word_file_name, base_name=word,
+                display_text=word, file_extension=self.file_extension,
+                extras=extras))

--- a/downloadaudio/downloaders/mw.py
+++ b/downloadaudio/downloaders/mw.py
@@ -14,6 +14,7 @@ import urllib
 import re
 
 from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
 
 
 def join_strings(a, b):
@@ -33,6 +34,7 @@ class MerriamWebsterDownloader(AudioDownloader):
     """Download audio from Meriam-Webster"""
     def __init__(self):
         AudioDownloader.__init__(self)
+        self.file_extension = u'.wav'
         self.url = 'http://www.merriam-webster.com/dictionary/'
         # Here the word page url works to get the favicon.
         self.icon_url = self.url
@@ -52,7 +54,6 @@ class MerriamWebsterDownloader(AudioDownloader):
         if split:
             # Avoid double downloads
             return
-        self.set_names(word, base, ruby)
         if not self.language.lower().startswith('en'):
             return
         if not word:
@@ -122,7 +123,9 @@ class MerriamWebsterDownloader(AudioDownloader):
                 word_path, word_file = self.get_word_file(mw_fn, word)
             except ValueError:
                 continue
-            self.downloads_list.append((word_path, word_file, extras))
+            self.downloads_list.append(DownloadEntry(
+                word_path, word_file, base_name=word, display_text=word,
+                file_extension=self.file_extension, extras=extras))
 
     def get_word_file(self, base_name, word):
         """
@@ -137,7 +140,7 @@ class MerriamWebsterDownloader(AudioDownloader):
         # The audio clip is the only embed tag.
         popup_embed = popup_soup.find(name='embed')
         word_data = self.get_data_from_url(popup_embed['src'])
-        word_path, word_fname = self.get_file_name()
+        word_path, word_fname = self.get_file_name(word, self.file_extension)
         with open(word_path, 'wb') as word_file:
             word_file.write(word_data)
         return word_path, word_fname

--- a/downloadaudio/downloaders/oald.py
+++ b/downloadaudio/downloaders/oald.py
@@ -16,6 +16,7 @@ import re
 import urllib
 
 from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
 
 
 # Work-around for broken BeautifulSoup
@@ -42,7 +43,6 @@ class OaldDownloader(AudioDownloader):
         if split:
             # Avoid double downloads
             return
-        self.set_names(word, base, ruby)
         if not self.language.lower().startswith('en'):
             return
         if not word:
@@ -61,7 +61,8 @@ class OaldDownloader(AudioDownloader):
             if not audio_url:
                 continue
             word_data = self.get_data_from_url(audio_url)
-            word_file_path, word_file_name = self.get_file_name()
+            word_file_path, word_file_name = self.get_file_name(
+                word, self.file_extension)
             with open(word_file_path, 'wb') as word_file:
                 word_file.write(word_data)
             extras = self.extras
@@ -74,5 +75,7 @@ class OaldDownloader(AudioDownloader):
                 if title_string:
                     extras = copy(self.extras)
                     extras['Title'] = title_string
-            self.downloads_list.append(
-                (word_file_path, word_file_name, extras))
+            self.downloads_list.append(DownloadEntry(
+                word_file_path, word_file_name, base_name=word,
+                display_text=word, file_extension=self.file_extension,
+                extras=extras))

--- a/downloadaudio/downloaders/wiktionary.py
+++ b/downloadaudio/downloaders/wiktionary.py
@@ -15,6 +15,7 @@ import urlparse
 import re
 
 from .downloader import AudioDownloader, uniqify_list
+from ..download_entry import DownloadEntry
 
 # Make this work without PyQt
 with_pyqt = True
@@ -51,7 +52,6 @@ class WiktionaryDownloader(AudioDownloader):
         if split:
             # Avoid double downloads.
             return
-        self.set_names(word, base, ruby)
         if not word:
             return
         u_word = urllib.quote(word.encode('utf-8'))
@@ -111,11 +111,14 @@ class WiktionaryDownloader(AudioDownloader):
                 word_data = self.get_data_from_url(word_url)
             except:
                 continue
-            word_path, word_fname = self.get_file_name()
+            word_path, word_fname = self.get_file_name(
+                word, self.file_extension)
             with open(word_path, 'wb') as word_file:
                 word_file.write(word_data)
-            self.downloads_list.append(
-                (word_path, word_fname, dict(Source="Wiktionary")))
+            self.downloads_list.append(DownloadEntry(
+                word_path, word_fname, base_name=word, display_text=word,
+                file_extension=self.file_extension,
+                extras=dict(Source="Wiktionary")))
 
     def maybe_get_icon(self):
         if self.site_icon:


### PR DESCRIPTION
New class DownloadEntry than contains information for each
downloaded audio file.

Tested all but leo, which seems to be defunct.

beolingus raises an exception for unsupported languages, instead of returning silently. This is inconvenient for testing, so I fixed it. Feel free to revert this part if you prefer the previous style.