### PR TITLE
add wwwjdic lookup for japanesepod downloader

### DIFF
--- a/downloadaudio/downloaders/beolingus.py
+++ b/downloadaudio/downloaders/beolingus.py
@@ -56,10 +56,10 @@ class BeolingusDownloader(AudioDownloader):
         if split:
             # Avoid double downloads
             return
-        lang = self.language[:2].lower()
-        if not lang in self.services_dict:
+        try:
+            self.service = self.services_dict[self.language[:2].lower()]
+        except KeyError:
             return
-        self.service = self.services_dict[lang]
         if not word:
             return
         word_soup = self.get_soup_from_url(self.build_word_url(word))

--- a/downloadaudio/downloaders/japanesepod.py
+++ b/downloadaudio/downloaders/japanesepod.py
@@ -11,22 +11,29 @@
 Download Japanese pronunciations from Japanesepod
 '''
 
+import re
 import urllib
+import urllib2
+import urlparse
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
 
+# dict translating katakana to corresponding hiragana codepoints
+katakana_to_hiragana = dict((i, i - 0x60) for i in range(0x30A1, 0x30F7))
 
 class JapanesepodDownloader(AudioDownloader):
     """Download audio from Japanesepod"""
     def __init__(self):
         AudioDownloader.__init__(self)
         self.file_extension = u'.mp3'
-        self.user_agent = '''Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:15.0) \
-Gecko/20100101 Firefox/15.0.1'''
+        self.user_agent = 'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:15.0) ' \
+            'Gecko/20100101 Firefox/15.0.1'
         self.icon_url = 'http://www.japanesepod101.com/'
         self.url = 'http://assets.languagepod101.com/' \
             'dictionary/japanese/audiomp3.php?'
+        self.wwwjdic_url = 'http://www.csse.monash.edu.au/~jwb/' \
+            'cgi-bin/wwwjdic.cgi?1MUJ'
 
     def download_files(self, word, base, ruby, split):
         """
@@ -45,41 +52,105 @@ Gecko/20100101 Firefox/15.0.1'''
             return
         if not split:
             return
-        file_extension = u'.mp3'
-        base_name, display_text = self.get_names(base, ruby)
         # Only get the icon when we are using Japanese.
         self.maybe_get_icon()
-        # Reason why we don't just do the get_data_.. bit inside the
+        self.get_word_from_japanesepod(base, ruby, False)
+        # First get from Japanesepod directly
+        # Maybe add other words via wwwjdic
+        if base == ruby:
+            # The base and the ruby are the same: probably a kana
+            # word. Look it up at WWWJDIC to get kanji spelling.
+            self.get_words_from_wwwjdic(ruby)
+
+    def get_word_from_japanesepod(self, kanji, kana, mark_wwwjdic):
+        base_name, display_text = self.get_names(kanji, kana)
+        # Reason why we don't just do the get_data_ bit inside the
         # with: Like this we don't have to clean up the temp file.
-        word_data = self.get_data_from_url(self.query_url(base, ruby))
+        word_data = self.get_data_from_url(self.jpod_url(kanji, kana))
         word_file_path, word_file_name = self.get_file_name(
-            base_name, file_extension)
+            base_name, self.file_extension)
         with open(word_file_path, 'wb') as word_file:
             word_file.write(word_data)
-        # We have a file, but not much to say about it.
-
+        extras = dict(Source='JapanesePod')
+        if mark_wwwjdic and kanji:
+            extras['Kanji'] = kanji
+            extras['Kanji source'] = 'WWWJDIC'
         self.downloads_list.append(DownloadEntry(
             word_file_path, word_file_name, base_name, display_text,
-            file_extension, extras=dict(Source='JapanesePod'),
+            file_extension=self.file_extension, extras=extras,
             show_skull_and_bones=True))
 
 
-    def query_url(self, kanji, kana):
+    def jpod_url(self, kanji, kana):
         u"""Return a string that can be used as the url."""
         qdict = {}
-        qdict['kanji'] = kanji.encode('utf-8')
+        if kanji:
+            qdict['kanji'] = kanji.encode('utf-8')
         if kana:
             qdict['kana'] = kana.encode('utf-8')
         return self.url + urllib.urlencode(qdict)
 
+    def get_words_from_wwwjdic(self, kana):
+    
+        soup = self.get_soup_from_url(
+                self.wwwjdic_url
+                + urllib2.quote(kana.encode('utf-8'))
+                + '_2_50') # get 50 entries (no idea what the 2 means)
+        labels = soup.findAll('label')
+        hits = set()
+        for l in labels:
+            audio = l.find('script')
+            entry = l.find('font')
+            if not audio or not entry or not entry.has_key('size') \
+                or entry['size'] != '+1':
+                continue
+            audio = re.search(r'm\("(.*)"\);', audio.text).group(1)
+            # string is quoted twice, so unquote it once
+            audio = urllib2.unquote(audio)
+            entry = entry.text
+            # strip "(P)" and similar markers
+            entry = re.sub(r'\(.*?\)', '', entry)
+            # convert brackets to delimiter
+            entry = re.sub(u'[\s\u300a\u300b\u3010\u3011]', ';', entry)
+            for reading in entry.split(';'):
+                if reading == kana:
+                    hits.add(audio)
+                    break
+        
+        for audio in hits:
+            args = urlparse.parse_qs(audio.encode('utf-8'))
+            audio_kanji = args['kanji'][0].decode('utf-8') \
+                if 'kanji' in args else None
+            audio_kana = args['kana'][0].decode('utf-8') \
+                if 'kana' in args else None
+            # Sometimes there are multiple readings. Check that the audio
+            # file is actually for the reading that we want.
+            if audio_kana and not self.equals_kana(audio_kana, kana):
+                continue
+            if not audio_kanji or audio_kana == audio_kanji:
+                # Probably got this file already in the first round.
+                continue
+            self.get_word_from_japanesepod(audio_kanji, audio_kana, True)
+    
     def get_names(self, base, ruby):
         """
         Get the display text and file base name variables.
         """
-        base_name = base
-        display_text = base
-        if ruby:
-            base_name += u'_' + ruby
-            display_text += u' (' + ruby + u')'
+        if base:
+            base_name = base
+            display_text = base
+            if ruby:
+                base_name += u'_' + ruby
+                display_text += u' (' + ruby + u')'
+        else:
+            base_name = ruby
+            display_text = ruby
         return base_name, display_text
 
+    def equals_kana(self, kana1, kana2):
+        """
+        Compare two strings - a string in hiragana is considered equal
+        to the corresponding katakana string.
+        """
+        return kana1.translate(katakana_to_hiragana) == \
+            kana2.translate(katakana_to_hiragana)


### PR DESCRIPTION
japanesepod insists on the kanji spelling (if there is any),
even for word commonly written in hiragana. Use wwwjdic
to look up the kanji. see #45.
(based on code by ospalh, see #48)