### PR TITLE
fixed leo.org downloader

### DIFF
--- a/downloadaudio/downloaders/leo.py
+++ b/downloadaudio/downloaders/leo.py
@@ -2,7 +2,6 @@
 #
 # Copyright © 2012–2013 Roland Sieker, ospalh@gmail.com
 # Copyright © 2015 Paul Hartmann <phaaurlt@gmail.com>
-# Inspiration and source of the URL: Tymon Warecki
 #
 # License: GNU AGPL, version 3 or later;
 # http://www.gnu.org/copyleft/agpl.html
@@ -12,9 +11,10 @@
 Download pronunciations from leo.org
 '''
 
-import os
-import sys
+from collections import OrderedDict
+import re
 import urllib
+import xml.etree.ElementTree as ElementTree
 
 # Make this work without PyQt
 with_pyqt = True
@@ -32,105 +32,112 @@ class LeoDownloader(AudioDownloader):
     def __init__(self):
         AudioDownloader.__init__(self)
         self.file_extension = u'.mp3'
-        self.url = 'http://www.leo.org/dict/audio_{language}/{word}.mp3'
+        self.dic_url = \
+            'http://dict.leo.org/dictQuery/m-vocab/{lang}de/query.xml?' \
+            'tolerMode=nof&lp={lang}de&lang=de&rmWords=off&rmSearch=on' \
+            '&search={word}&searchLoc={direction}&resultOrder=basic' \
+            '&multiwordShowSingle=on&sectLenMax=16'
+        self.SEARCH_DIRECTION = { 'from_german': '1', 'to_german': '-1' }
+        self.audio_url = 'http://dict.leo.org/media/audio/{id}.mp3'
         # And, yes, they use ch for Chinese.
-        # (I'm not sure if they really have anything for ru or it.)
-        self.language_dict = {'de': 'de', 'en': 'en', 'es': 'es', 'fr': 'fr',
-                              'it': 'it', 'ru': 'ru', 'zh': 'ch'}
-        # It kind of looks like they have Swiss pronunciations, but hey don't.
-        self.chinese_code = 'ch'
+        self.language_dict = {'de': 'de', 'en': 'en', 'fr': 'fr', 'es': 'es',
+                              # at time of writing, leo.org has no audio for the
+                              # following languages
+                              #'it': 'it', 'zh': 'ch', 'ru': 'ru', 'pt': 'pt',
+                              #'pl': 'pl'
+                              }
         # We should keep a number of site icons handy, with the right
         # flag for the request.
         self.site_icon_dict = {}
-        self.site_file_name_encoding = 'ISO-8859-1'
         self.icon_url_dict = {
-            'de': 'http://dict.leo.org/favicon.ico',
-            'en': 'http://dict.leo.org/favicon.ico',
-            'es': 'http://dict.leo.org/favicon_es.ico',
-            'fr': 'http://dict.leo.org/favicon_fr.ico',
-            'it': 'http://dict.leo.org/favicon_it.ico',
-            'ru': 'http://dict.leo.org/favicon_ru.ico',
-            # When we use this dict, we have already munged the 'zh' to 'ch'
-            'ch': 'http://dict.leo.org/favicon_ch.ico'}
-        # As the name implies, a hack. Try to use the cjklib TTEMPÉ
-        # brings along. A syntem-wide installed one should work as
-        # well.
-        self.have_tried_cjklib_hack = False
-        self.reading_factory = None
+            'de': 'http://dict.leo.org/img/favicons/ende.ico',
+            'en': 'http://dict.leo.org/img/favicons/ende.ico',
+            'fr': 'http://dict.leo.org/img/favicons/frde.ico',
+            'es': 'http://dict.leo.org/img/favicons/esde.ico',
+            #'it': 'http://dict.leo.org/img/favicons/itde.ico',
+            # # When we use this dict, we have already munged the 'zh' to 'ch'
+            #'ch': 'http://dict.leo.org/img/favicons/chde.ico',
+            #'ru': 'http://dict.leo.org/img/favicons/rude.ico',
+            #'pt': 'http://dict.leo.org/img/favicons/ptde.ico',
+            #'pl': 'http://dict.leo.org/img/favicons/plde.ico'
+            }
 
     def download_files(self, word, base, ruby, split):
         """
         Download a word from LEO
-
-        We try to get pronunciations for the text for German, English,
-        Spanish, French, Italian and Russian, and from the ruby for
-        Chinese. There may not be any pronunciations available for
-        Italian or Russian.
         """
+#        from aqt.qt import debug; debug()
         self.downloads_list = []
-        # Fix the language. EAFP.
-        self.language = self.language_dict[self.language[:2].lower()]
-        # get_names also checks the language.
-        base_name, display_text = self.get_names(word, base, ruby)
-        if self.chinese_code == self.language and not split:
+        if split:
+            # Avoid double downloads
             return
-        # Only get the icon when we have a word
-        # self.maybe_get_icon()
+        # Fix the language. EAFP.
+        try:
+            self.language = self.language_dict[self.language[:2].lower()]
+        except KeyError:
+            return
+
         self.get_flag_icon()
-        # EAFP. self.query_url may return None...
-        word_url = self.query_url(word, ruby)
-        # ... then the get_data will blow up
-        word_data = self.get_data_from_url(word_url)
+
+        # To find the audio links, look up dictionary entries, which are
+        # en<->de, fr<->de, es<->de, etc.
+        # For German entries, use de->en.
+        if self.language == 'de':
+            query_lang = 'en'
+            direction = self.SEARCH_DIRECTION['from_german']
+        else:
+            query_lang = self.language
+            direction = self.SEARCH_DIRECTION['to_german']
+
+        xml = self.get_data_from_url(self.dic_url.format(lang=query_lang,
+            word=urllib.quote_plus(word.encode('utf-8')), direction=direction))
+        root = ElementTree.fromstring(xml)
+        hits = OrderedDict()
+        for section in root.findall('sectionlist/section'):
+            for entry in section.findall('entry'):
+                if self.language == 'de':
+                     # Second side is always German.
+                    side = entry.findall('side')[1]
+                else:
+                     # And the first side the other requested language.
+                    side = entry.findall('side')[0]
+                if side.attrib['lang'] != self.language: # consistency check
+                    raise ValueError()
+
+                matching_word = None
+                for el_word in side.findall('words/word'):
+                    cur_word = el_word.text
+                    # Text in ElementTree has inconsistent types: "str" when it
+                    # contains only ASCII characters and "unicode" otherwise.
+                    # Make everything unicode.
+                    if type(cur_word) == str:
+                        cur_word = cur_word.decode('utf-8')
+                    if self.normalize(cur_word) == self.normalize(word):
+                        matching_word = cur_word
+                        break
+                if not matching_word:
+                    continue
+                pron = side.find('ibox/pron')
+                if pron is None:
+                    continue # no audio file for this entry
+                audio_id = pron.attrib['url']
+                hits[audio_id] = matching_word
+        for audio_id, matching_word in hits.items():
+            self.download_audio(audio_id, self.adjust_to_audio(matching_word))
+
+    def download_audio(self, audio_id, word):
+        """
+        Download audio file with a given id from leo.org.
+        """
+        word_data = self.get_data_from_url(self.audio_url.format(id=audio_id))
         word_file_path, word_file_name = self.get_file_name(
             word, self.file_extension)
         with open(word_file_path, 'wb') as word_file:
             word_file.write(word_data)
         # We have a file, but not much to say about it.
         self.downloads_list.append(DownloadEntry(
-            word_file_path, word_file_name, base_name, display_text,
+            word_file_path, word_file_name, base_name=word, display_text=word,
             file_extension=self.file_extension, extras=dict(Source='Leo')))
-
-    def query_url(self, word, ruby):
-        """Build query URL"""
-        if self.chinese_code == self.language:
-            word = self.fix_pinyin(ruby)
-        return self.url.format(
-            language=self.language, word=urllib.quote(word.encode(
-                self.site_file_name_encoding)))
-
-    def fix_pinyin(self, pinyin):
-        # Hacks. It is overkill to ship cjklib with this add-on. But
-        # to get the tone numbers as numbers, we should use it. My
-        # hope (guess) is that the typical user that will want Chinese
-        # pronunciations will also have TTEMPÉ's (version of mine)
-        # chinese-support-plugin installed. So try to use that and
-        # don't complain if it doesn't work.
-        if not self.have_tried_cjklib_hack:
-            try:
-                # If this works, the whole shebang is run as an Anki2
-                # add-on. If not, we will still look for a system-wide
-                # cjklib, but obviously not for anothre add-on.
-                from aqt.utils import isWin
-            except:
-                pass
-            else:
-                from aqt import mw
-                addon_dir = mw.pm.addonFolder()
-                if isWin:
-                    # The isWin bit is copied from TTEMPÉ's code.
-                    addon_dir = addon_dir.encode(sys.getfilesystemencoding())
-                sys.path.append(os.path.join(addon_dir, "chinese"))
-            self.have_tried_cjk_hack = True
-        if not self.reading_factory:
-            try:
-                from cjklib.reading import ReadingFactory
-            except ImportError:
-                return pinyin
-            else:
-                self.reading_factory = ReadingFactory()
-        return self.reading_factory.convert(
-            pinyin, 'Pinyin',  'Pinyin', targetOptions={
-                'toneMarkType': 'numbers'}).replace('5', '0')
 
     def get_flag_icon(self):
         """
@@ -153,18 +160,50 @@ class LeoDownloader(AudioDownloader):
                     self.icon_url_dict[self.language]))
             self.site_icon = self.site_icon_dict[self.language]
 
-    def get_names(self, text, base, ruby):
+    def normalize(self, word):
         """
-        Get the file base name and display text variables.
+        For comparison of two words / entries, strip articles, particles and
+        similar words.
+
+        Typically these additional words give extra information, but do not
+        change the identity of the main phrase or word.
+        Therefore they are removed before matching the user request with the
+        dictionary entry.
         """
-        if self.language == self.chinese_code:
-            if not ruby:
-                raise ValueError('Nothing to download')
-            base_name = u"{0}_{1}".format(base, ruby)
-            display_text = u"{1} ({0})".format(base, ruby)
-        else:
-            if not text:
-                raise ValueError('Nothing to download')
-            base_name = text
-            display_text = text
-        return base_name, display_text
+        if self.language == 'de':
+            addenda = ['der', 'die', 'das']
+        elif self.language == 'en':
+            addenda = ['to', 'sth.', 'so.']
+        elif self.language == 'fr':
+            addenda = ['le', 'la', 'qn.', 'qc.']
+        elif self.language == 'es':
+            addenda = ['el', 'la']
+        word = word.lower()
+        for a in addenda:
+            word = re.sub('^{} '.format(a), '', word)
+            word = re.sub(',? {}$'.format(a), '', word)
+        return word
+
+    def adjust_to_audio(self, word):
+        """
+        Adjusts the dictionary text to what is actually spoken in the audio
+        file.
+
+        There are certain patterns, for example in Spanish, articles for nouns
+        are included in the dictionary text, but not in the audio.
+        Similarly, the verb-entries in English have a "to" in front, which is
+        omitted in the audio.
+        """
+        if self.language == 'de':
+            addenda = []
+        elif self.language == 'en':
+            addenda = ['to']
+        elif self.language == 'fr':
+            addenda = ['qn.', 'qc.']
+        elif self.language == 'es':
+            addenda = ['el', 'la']
+        for a in addenda:
+            word = re.sub('^{} '.format(a), '', word)
+            word = re.sub(',? {}$'.format(a), '', word)
+        return word
+

--- a/downloadaudio/downloaders/leo.py
+++ b/downloadaudio/downloaders/leo.py
@@ -1,0 +1,170 @@
+# -*- mode: python; coding: utf-8 -*-
+#
+# Copyright © 2012–2013 Roland Sieker, ospalh@gmail.com
+# Copyright © 2015 Paul Hartmann <phaaurlt@gmail.com>
+# Inspiration and source of the URL: Tymon Warecki
+#
+# License: GNU AGPL, version 3 or later;
+# http://www.gnu.org/copyleft/agpl.html
+
+
+'''
+Download pronunciations from leo.org
+'''
+
+import os
+import sys
+import urllib
+
+# Make this work without PyQt
+with_pyqt = True
+try:
+    from PyQt4.QtGui import QImage
+except ImportError:
+    with_pyqt = False
+
+from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
+
+
+class LeoDownloader(AudioDownloader):
+    """Download audio from LEO"""
+    def __init__(self):
+        AudioDownloader.__init__(self)
+        self.file_extension = u'.mp3'
+        self.url = 'http://www.leo.org/dict/audio_{language}/{word}.mp3'
+        # And, yes, they use ch for Chinese.
+        # (I'm not sure if they really have anything for ru or it.)
+        self.language_dict = {'de': 'de', 'en': 'en', 'es': 'es', 'fr': 'fr',
+                              'it': 'it', 'ru': 'ru', 'zh': 'ch'}
+        # It kind of looks like they have Swiss pronunciations, but hey don't.
+        self.chinese_code = 'ch'
+        # We should keep a number of site icons handy, with the right
+        # flag for the request.
+        self.site_icon_dict = {}
+        self.site_file_name_encoding = 'ISO-8859-1'
+        self.icon_url_dict = {
+            'de': 'http://dict.leo.org/favicon.ico',
+            'en': 'http://dict.leo.org/favicon.ico',
+            'es': 'http://dict.leo.org/favicon_es.ico',
+            'fr': 'http://dict.leo.org/favicon_fr.ico',
+            'it': 'http://dict.leo.org/favicon_it.ico',
+            'ru': 'http://dict.leo.org/favicon_ru.ico',
+            # When we use this dict, we have already munged the 'zh' to 'ch'
+            'ch': 'http://dict.leo.org/favicon_ch.ico'}
+        # As the name implies, a hack. Try to use the cjklib TTEMPÉ
+        # brings along. A syntem-wide installed one should work as
+        # well.
+        self.have_tried_cjklib_hack = False
+        self.reading_factory = None
+
+    def download_files(self, word, base, ruby, split):
+        """
+        Download a word from LEO
+
+        We try to get pronunciations for the text for German, English,
+        Spanish, French, Italian and Russian, and from the ruby for
+        Chinese. There may not be any pronunciations available for
+        Italian or Russian.
+        """
+        self.downloads_list = []
+        # Fix the language. EAFP.
+        self.language = self.language_dict[self.language[:2].lower()]
+        # get_names also checks the language.
+        base_name, display_text = self.get_names(word, base, ruby)
+        if self.chinese_code == self.language and not split:
+            return
+        # Only get the icon when we have a word
+        # self.maybe_get_icon()
+        self.get_flag_icon()
+        # EAFP. self.query_url may return None...
+        word_url = self.query_url(word, ruby)
+        # ... then the get_data will blow up
+        word_data = self.get_data_from_url(word_url)
+        word_file_path, word_file_name = self.get_file_name(
+            word, self.file_extension)
+        with open(word_file_path, 'wb') as word_file:
+            word_file.write(word_data)
+        # We have a file, but not much to say about it.
+        self.downloads_list.append(DownloadEntry(
+            word_file_path, word_file_name, base_name, display_text,
+            file_extension=self.file_extension, extras=dict(Source='Leo')))
+
+    def query_url(self, word, ruby):
+        """Build query URL"""
+        if self.chinese_code == self.language:
+            word = self.fix_pinyin(ruby)
+        return self.url.format(
+            language=self.language, word=urllib.quote(word.encode(
+                self.site_file_name_encoding)))
+
+    def fix_pinyin(self, pinyin):
+        # Hacks. It is overkill to ship cjklib with this add-on. But
+        # to get the tone numbers as numbers, we should use it. My
+        # hope (guess) is that the typical user that will want Chinese
+        # pronunciations will also have TTEMPÉ's (version of mine)
+        # chinese-support-plugin installed. So try to use that and
+        # don't complain if it doesn't work.
+        if not self.have_tried_cjklib_hack:
+            try:
+                # If this works, the whole shebang is run as an Anki2
+                # add-on. If not, we will still look for a system-wide
+                # cjklib, but obviously not for anothre add-on.
+                from aqt.utils import isWin
+            except:
+                pass
+            else:
+                from aqt import mw
+                addon_dir = mw.pm.addonFolder()
+                if isWin:
+                    # The isWin bit is copied from TTEMPÉ's code.
+                    addon_dir = addon_dir.encode(sys.getfilesystemencoding())
+                sys.path.append(os.path.join(addon_dir, "chinese"))
+            self.have_tried_cjk_hack = True
+        if not self.reading_factory:
+            try:
+                from cjklib.reading import ReadingFactory
+            except ImportError:
+                return pinyin
+            else:
+                self.reading_factory = ReadingFactory()
+        return self.reading_factory.convert(
+            pinyin, 'Pinyin',  'Pinyin', targetOptions={
+                'toneMarkType': 'numbers'}).replace('5', '0')
+
+    def get_flag_icon(self):
+        """
+        Set self.site_icon to the right icon.
+
+        We should use different icons, depending on the request
+        language.  We store these icons in self.site_icon_dict and use the
+        AudioDownloader.maybe_get_icon() if we don't have it yet.
+        """
+        if not with_pyqt:
+            return
+        try:
+            # If this works we already have it.
+            self.site_icon = self.site_icon_dict[self.language]
+        except KeyError:
+            # We have to get it ourself. (We know it's just 16x16, so
+            # no resize. And we know the address).
+            self.site_icon_dict[self.language] = \
+                QImage.fromData(self.get_data_from_url(
+                    self.icon_url_dict[self.language]))
+            self.site_icon = self.site_icon_dict[self.language]
+
+    def get_names(self, text, base, ruby):
+        """
+        Get the file base name and display text variables.
+        """
+        if self.language == self.chinese_code:
+            if not ruby:
+                raise ValueError('Nothing to download')
+            base_name = u"{0}_{1}".format(base, ruby)
+            display_text = u"{1} ({0})".format(base, ruby)
+        else:
+            if not text:
+                raise ValueError('Nothing to download')
+            base_name = text
+            display_text = text
+        return base_name, display_text


### PR DESCRIPTION
This makes the LeoDownloader work with the current website.

I couldn't find any Chinese audio files on leo.org, so removed the special handling code for this language.
This downloader will be most useful for French and Spanish: The Collins audio sometimes sounds like a robotic voice, while on leo it is more natural (examples (fr): vaincre, référendum). Moreover it has audio data for words that are currently not covered.

German is already well supported, especially by Duden. However, leo includes the article of nouns in the spoken text, so it might be useful for learners having trouble with der/die/das.

The English audios are clear and consistent. Although there are already a lot of English downloaders, this beats for example Merriam-Webster and HowJSay (no offense to the speakers, but the recording/encoding quality is bad for these two).
