### PR TITLE
Audio Downloader for Danish (Den Danske Ordbog)

### DIFF
--- a/downloadaudio/downloaders/__init__.py
+++ b/downloadaudio/downloaders/__init__.py
@@ -33,6 +33,7 @@ from .macmillan_british import MacmillanBritishDownloader
 from .mw import MerriamWebsterDownloader
 from .oald import OaldDownloader
 from .wiktionary import WiktionaryDownloader
+from .den_danske_ordbog import DenDanskeOrdbogDownloader
 
 
 downloaders = [
@@ -45,6 +46,7 @@ downloaders = [
     MacmillanBritishDownloader(),
     OaldDownloader(),
     DudenDownloader(),
+    DenDanskeOrdbogDownloader(),
     HowJSayDownloader(),
     CollinsFrenchDownloader(),
     CollinsGermanDownloader(),

--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -33,3 +33,16 @@ class DenDanskeOrdbogDownloader(AudioDownloader):
             return
         self.downloads_list = []
 
+        search_soup = self.get_soup_from_url(
+            self.url + urllib.urlencode(
+                dict(query=field_data.word)))
+
+        search_results = search_soup.find(
+            'div', {'class': 'searchResultBox'}).findAll('a')
+
+        # If no hits we have an empty list now
+        if search_results:
+            self.maybe_get_icon()
+
+        for link in search_results:
+            # Do something...

--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -23,3 +23,13 @@ class DenDanskeOrdbogDownloader(AudioDownloader):
         AudioDownloader.__init__(self)
         self.url = 'http://ordnet.dk/ddo/ordbog?'
         self.icon_url = 'http://ordnet.dk/'
+
+    def download_files(self, field_data):
+        if not self.language.lower().startswith('da'):
+            return
+        if field_data.split:
+            return
+        if not field_data.word:
+            return
+        self.downloads_list = []
+

--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -1,0 +1,25 @@
+# -*- mode: python; coding: utf-8 -*-
+#
+# Copyright © 2015 Daniel Eriksson <daniel@deriksson.se>
+# Copyright © 2015 Roland Sieker <ospalh@gmail.com>
+#
+# License: GNU AGPL, version 3 or later;
+# http://www.gnu.org/copyleft/agpl.html
+
+
+"""
+Download pronunciations for Danish from Den Danske Ordbog
+"""
+
+import urllib
+from .downloader import AudioDownloader
+from ..download_entry import DownloadEntry
+
+
+class DenDanskeOrdbogDownloader(AudioDownloader):
+    """Download audio from Den Danske Ordbog"""
+
+    def __init__(self):
+        AudioDownloader.__init__(self)
+        self.url = 'http://ordnet.dk/ddo/ordbog?'
+        self.icon_url = 'http://ordnet.dk/'

--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -51,15 +51,18 @@ class DenDanskeOrdbogDownloader(AudioDownloader):
                 word_soup = self.get_soup_from_url(
                     link['href'].encode('utf-8'))
                 audio_link = word_soup.find('audio').find('a')['href']
+
+                entry = DownloadEntry(
+                    field_data,
+                    self.get_tempfile_from_url(audio_link),
+                    dict(Source='Den Danske Ordbog'),
+                    self.site_icon)
+
             except (AttributeError, KeyError, HTTPError):
                 # Getting HTTPErrors sometimes. could it be rate limiting?
                 continue
-            entry = DownloadEntry(
-                field_data,
-                self.get_tempfile_from_url(audio_link),
-                dict(Source='Den Danske Ordbog'),
-                self.site_icon)
 
+            # Try to get the display name from the dictionary
             try:
                 # BeautifulSoup doesn't unescape properly. Why?
                 entry.word = HTMLParser().unescape(
@@ -68,4 +71,3 @@ class DenDanskeOrdbogDownloader(AudioDownloader):
                 pass
 
             self.downloads_list.append(entry)
-

--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -27,13 +27,13 @@ class DenDanskeOrdbogDownloader(AudioDownloader):
         self.icon_url = 'http://ordnet.dk/'
 
     def download_files(self, field_data):
+        self.downloads_list = []
         if not self.language.lower().startswith('da'):
             return
         if field_data.split:
             return
         if not field_data.word:
             return
-        self.downloads_list = []
 
         search_soup = self.get_soup_from_url(
             self.url + urllib.urlencode(


### PR DESCRIPTION
I found yet another Scandinavian language and couldn't resist writing a downloader for it. Not sure if anyone would volunteer to learn Danish though...

As of now, a superscript ordinal number will follow through to the display name. For example, 'den2'. Not sure if this is a feature or a bug.

Let me know if you think this is getting out of hand. At least I think I'm out of dictionaries for now.