### PR TITLE
New lexin downloader

### DIFF
--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -57,8 +57,13 @@ class LexinDownloader(AudioDownloader):
             return
         if not field_data.word:
             return
-        # Replace special characters with ISO-8859-1 oct codes
         self.maybe_get_icon()
+        self.download_v1(field_data)
+
+    def download_v1(self, field_data):
+        """Get pronunciations of a word in Swedish from Lexin
+        using the old v1 url structure."""
+
         file_path = self.get_tempfile_from_url(
             self.url + munge_word(field_data.word) + self.file_extension)
         self.downloads_list.append(

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -62,7 +62,7 @@ class LexinDownloader(AudioDownloader):
         if not field_data.word:
             return
         self.maybe_get_icon()
-        self.download_v1(field_data)
+        v1_downloaded = False
         # These headers are necessary
         # Without them, the server returns 500 response
         headers = {
@@ -81,6 +81,7 @@ class LexinDownloader(AudioDownloader):
         try:
             response = urllib2.urlopen(request)
         except:
+            self.download_v1(field_data)
             return
         # Strip leading '//OK' and
         # exchange invalid hex escapes with unicode escapes
@@ -106,6 +107,11 @@ class LexinDownloader(AudioDownloader):
                     self.get_tempfile_from_url(audio_link),
                     extras,
                     self.site_icon)
+                if audio_file == field_data.word + '.mp3':
+                    # This is a file from the legacy v1 collection
+                    # Some v1 files have been abandoned, but are still
+                    # out there.
+                    v1_downloaded = True
             except:
                 continue
             try:
@@ -113,6 +119,13 @@ class LexinDownloader(AudioDownloader):
             except AttributeError:
                 pass
             self.downloads_list.append(entry)
+        if not v1_downloaded:
+            # Try downloading a file with the old <word>.mp3 filename
+            # if it has not already been downloaded.
+            try:
+                self.download_v1(field_data)
+            except:
+                pass
 
     def download_v1(self, field_data):
         """Get pronunciations of a word in Swedish from Lexin

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -13,6 +13,7 @@ Download pronunciations from Lexin.
 """
 
 import unicodedata
+import urllib2
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -60,6 +61,25 @@ class LexinDownloader(AudioDownloader):
             return
         self.maybe_get_icon()
         self.download_v1(field_data)
+        # These headers are necessary
+        # Without them, the server returns 500 response
+        headers = {
+            'Content-Type': 'text/x-gwt-rpc; charset=utf-8',
+            'X-GWT-Permutation': 'B3637EFE47DBD18879B4B4582D033CEA'}
+        # GWT-RPC encoded payload string
+        payload = (
+            '7|0|7|http://lexin.nada.kth.se/lexin/lexin/|'
+            'FCDCCA88916BAACF8B03FB48D294BA89|'
+            'se.jojoman.lexin.lexingwt.client.LookUpService|'
+            'lookUpWord|se.jojoman.lexin.lexingwt.client.LookUpRequest/682723451|swe_swe|' +
+            field_data.word.encode('utf-8') + '|1|2|3|4|1|5|5|1|6|1|7|')
+        request = urllib2.Request(
+            self.url,
+            payload, headers)
+        try:
+            response = urllib2.urlopen(request)
+        except:
+            pass
 
     def download_v1(self, field_data):
         """Get pronunciations of a word in Swedish from Lexin

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -1,7 +1,7 @@
 # -*- mode: python; coding: utf-8 -*-
 #
 # Copyright © 2012–15 Roland Sieker <ospalh@gmail.com>
-# Copyright © 2014 Daniel Eriksson, p.e.d.eriksson@gmail.com
+# Copyright © 2014-15 Daniel Eriksson, <daniel@deriksson.se>
 # Copyright © 2015 Paul Hartmann <phaaurlt@gmail.com>
 #
 # License: GNU AGPL, version 3 or later;

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -46,7 +46,8 @@ class LexinDownloader(AudioDownloader):
     def __init__(self):
         AudioDownloader.__init__(self)
         self.icon_url = 'http://lexin.nada.kth.se/lexin/'
-        self.url = 'http://lexin.nada.kth.se/sound/'
+        self.url = 'http://lexin.nada.kth.se/lexin/lexin/lookupword'
+        self.audio_url = 'http://lexin.nada.kth.se/sound/'
 
     def download_files(self, field_data):
         """Get pronunciations of a word in Swedish from Lexin"""
@@ -65,7 +66,9 @@ class LexinDownloader(AudioDownloader):
         using the old v1 url structure."""
 
         file_path = self.get_tempfile_from_url(
-            self.url + munge_word(field_data.word) + self.file_extension)
+            self.audio_url +
+            munge_word(field_data.word) +
+            self.file_extension)
         self.downloads_list.append(
             DownloadEntry(
                 field_data, file_path, dict(Source="Lexin"), self.site_icon))

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -91,6 +91,11 @@ class LexinDownloader(AudioDownloader):
         word_xmls = json.loads(data)[-3][3:-2]
         for word_xml in word_xmls:
             soup = BeautifulSoup(word_xml)
+            extras = dict(Source='Lexin')
+            try:
+                extras['Type'] = soup.find('lemma')['type']
+            except AttributeError:
+                pass
             try:
                 audio_file = soup.find('phonetic')['file']
                 # Sometimes we get files using the old filename style
@@ -103,6 +108,10 @@ class LexinDownloader(AudioDownloader):
                     self.site_icon)
             except:
                 continue
+            try:
+                entry.word = soup.find('lemma')['value']
+            except AttributeError:
+                pass
             self.downloads_list.append(entry)
 
     def download_v1(self, field_data):


### PR DESCRIPTION
This addresses issue #77. This is a bit messy but it works for most cases.

Some words still use the old files `<word>.mp3` whereas most words have new files with names on the form `v2/<id>_<n>.mp3`. Since there are files out there that can be reached by the current downloader, but not from the website or from this new downloader, I chose not to replace the old one completely.

There is also an issue with words containing umlauts and using the old filename structure. From the xml I get filenames such as `är.mp3`, but there are no such files. Theses filenames must converted on the fly using the oct-code scheme we implemented in the old lexin downloader. Or is this weird thing built in to javascript? A quick and dirty solution is to just import the `munge_word` function from lexin as I've done on a different branch: b008c7122d190637df3f0897c5ba9cbdebb14cfe.

While this would fix the issue, it would only lead to downloading of duplicates if the old lexin downloader is still in use. One could also try merging the two downloaders. Adding an attempt to download a file named `<word>.mp3` if it is not already included in the search results.