### PR TITLE
Fix column order of due and new count

### DIFF
--- a/show_learn_count.py
+++ b/show_learn_count.py
@@ -82,9 +82,9 @@ def deck_browser_deck_row(deck_browser, node, depth, cnt):
         return """<span style='color: {};'>{}</span>""".format(colour, cnt)
     buf += """\
 <td align=right>%s</td><td align=right>%s</td><td align=right>%s</td>""" % (
-        nonzeroColour(due, "#009"),
+        nonzeroColour(new, "#009"),
         nonzeroColour(lrn, "#900"),
-        nonzeroColour(new, "#070"))
+        nonzeroColour(due, "#070"))
     # options
     buf += "<td align=right class=opts>%s</td></tr>" % deck_browser.mw.button(
         link="opts:%d" % did,


### PR DESCRIPTION
The order of new and due count were mixed up in show_learn_count.py. This caused due counts to show  up in the new column and vice-versa. With this commit everything is back in order.

Thanks for writing this add-on, by the way. Makes reviewing far more consistent between Anki and Ankidroid. You should really consider publishing this on Ankiweb. I am sure a lot of users would appreciate that.