### PR TITLE
Port downloadaudio to Anki 2.1

### DIFF
--- a/add_kanji_embeds.py
+++ b/add_kanji_embeds.py
@@ -26,8 +26,9 @@ import os
 import re
 import sys
 
-from PyQt4.QtCore import SIGNAL
-from PyQt4.QtGui import QAction
+from PyQt5.QtCore import SIGNAL
+from PyQt5.QtWidgets import QAction
+
 
 # The rest of the anki componets.
 from aqt.utils import askUser, tooltip

--- a/add_note_id.py
+++ b/add_note_id.py
@@ -18,8 +18,9 @@ Anki2 add-on to make notes unique
 Add the note id to a field named Note ID in
 """
 
-from PyQt4.QtCore import QCoreApplication, SIGNAL
-from PyQt4.QtGui import QAction, QProgressDialog
+from PyQt5.QtCore import QCoreApplication, SIGNAL
+from PyQt5.QtWidgets import QAction, QProgressDialog
+
 
 from anki.hooks import addHook
 from anki.lang import _

--- a/colorful_toolbars.py
+++ b/colorful_toolbars.py
@@ -27,8 +27,9 @@ main window. By default a few buttons (QActions) are added, more can
 be added by the user.
 """
 
-from PyQt4.QtCore import QSize, Qt, SIGNAL
-from PyQt4.QtGui import QAction, QIcon, QMenu, QPalette, QToolBar
+from PyQt5.QtCore import QSize, Qt, SIGNAL
+from PyQt5.QtGui import QIcon, QPalette
+from PyQt5.QtWidgets import QAction, QMenu, QToolBar
 import os
 
 from anki.hooks import wrap, addHook

--- a/downloadaudio/download.py
+++ b/downloadaudio/download.py
@@ -35,8 +35,10 @@ manual.
 """
 
 import os
-from PyQt4.QtGui import QAction, QIcon, QMenu
-from PyQt4.QtCore import SIGNAL
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QAction, QMenu
+from PyQt5.QtCore import SIGNAL
+
 
 from aqt import mw
 from aqt.utils import tooltip

--- a/downloadaudio/download.py
+++ b/downloadaudio/download.py
@@ -37,7 +37,6 @@ manual.
 import os
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QAction, QMenu
-from PyQt5.QtCore import SIGNAL
 
 
 from aqt import mw
@@ -235,7 +234,7 @@ mw.note_download_action.setIcon(QIcon(os.path.join(icons_dir,
 mw.note_download_action.setToolTip(
     "Download audio for all audio fields of this note.")
 mw.note_download_action.setShortcut(DOWNLOAD_NOTE_SHORTCUT)
-mw.connect(mw.note_download_action, SIGNAL("triggered()"), download_for_note)
+mw.note_download_action.triggered.connect(download_for_note)
 
 mw.side_download_action = QAction(mw)
 mw.side_download_action.setText(u"Side audio")
@@ -244,7 +243,7 @@ mw.side_download_action.setIcon(
 mw.side_download_action.setToolTip(
     "Download audio for audio fields currently visible.")
 mw.side_download_action.setShortcut(DOWNLOAD_SIDE_SHORTCUT)
-mw.connect(mw.side_download_action, SIGNAL("triggered()"), download_for_side)
+mw.side_download_action.triggered.connect(download_for_side)
 
 mw.manual_download_action = QAction(mw)
 mw.manual_download_action.setText(u"Manual audio")
@@ -253,7 +252,7 @@ mw.manual_download_action.setIcon(
 mw.manual_download_action.setToolTip(
     "Download audio, editing the information first.")
 mw.manual_download_action.setShortcut(DOWNLOAD_MANUAL_SHORTCUT)
-mw.connect(mw.manual_download_action, SIGNAL("triggered()"), download_manual)
+mw.manual_download_action.triggered.connect(download_manual)
 
 
 mw.edit_media_submenu.addAction(mw.note_download_action)

--- a/downloadaudio/downloaders/beolingus.py
+++ b/downloadaudio/downloaders/beolingus.py
@@ -11,7 +11,7 @@
 Download pronunciations from BeoLingus.
 '''
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import urlparse
 import re
 
@@ -97,7 +97,7 @@ class BeolingusDownloader(AudioDownloader):
         pop-up, isolate the "Listen with your default mp3 player" link
         from that, get the file that points to and get that.
         """
-        word_encoded = urllib.quote(word.encode('utf-8'))
+        word_encoded = urllib.parse.quote(word.encode('utf-8'))
         popup_url = re.sub(';text=.*$', ';text=' + word_encoded, popup_url)
         popup_url = urlparse.urljoin(self.site_url, popup_url)
         popup_soup = self.get_soup_from_url(popup_url)
@@ -114,4 +114,4 @@ class BeolingusDownloader(AudioDownloader):
     def build_word_url(self, source):
         u"""Put source into a dict useful as part of a url."""
         qdict = dict(service=self.service, query=source.encode('utf-8'))
-        return self.url + urllib.urlencode(qdict)
+        return self.url + urllib.parse.urlencode(qdict)

--- a/downloadaudio/downloaders/beolingus.py
+++ b/downloadaudio/downloaders/beolingus.py
@@ -12,7 +12,7 @@ Download pronunciations from BeoLingus.
 '''
 
 import urllib.request, urllib.parse, urllib.error
-import urlparse
+import urllib.parse
 import re
 
 from .downloader import AudioDownloader, uniqify_list
@@ -99,7 +99,7 @@ class BeolingusDownloader(AudioDownloader):
         """
         word_encoded = urllib.parse.quote(word.encode('utf-8'))
         popup_url = re.sub(';text=.*$', ';text=' + word_encoded, popup_url)
-        popup_url = urlparse.urljoin(self.site_url, popup_url)
+        popup_url = urllib.parse.urljoin(self.site_url, popup_url)
         popup_soup = self.get_soup_from_url(popup_url)
         # The audio link should be the only link.
         href_list = [a['href'] for a in popup_soup.findAll('a')]
@@ -109,7 +109,7 @@ class BeolingusDownloader(AudioDownloader):
         # If we don't have exactly one url, something's wrong. Assume
         # we have at least one.
         return self.get_tempfile_from_url(
-            urlparse.urljoin(self.site_url, href_list[0]))
+            urllib.parse.urljoin(self.site_url, href_list[0]))
 
     def build_word_url(self, source):
         u"""Put source into a dict useful as part of a url."""

--- a/downloadaudio/downloaders/collins.py
+++ b/downloadaudio/downloaders/collins.py
@@ -14,7 +14,7 @@ Download pronunciations from Collins dictionary
 Abstract base class, derived for several languages.
 """
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from .downloader import AudioDownloader, uniqify_list
 from ..download_entry import Action, DownloadEntry
@@ -54,7 +54,7 @@ class CollinsDownloader(AudioDownloader):
         lword = field_data.word.lower()
         # Do our parsing with BeautifulSoup
         word_soup = self.get_soup_from_url(
-            self.url + urllib.quote(lword.encode('utf-8')))
+            self.url + urllib.parse.quote(lword.encode('utf-8')))
         html_tag_with_audio_url = word_soup.find(
             name='a', attrs={'class': 'hwd_sound sound audio_play_button'})
         if not html_tag_with_audio_url:

--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -11,8 +11,8 @@
 Download pronunciations for Danish from Den Danske Ordbog
 """
 
-import urllib
-from urllib2 import HTTPError
+import urllib.request, urllib.parse, urllib.error
+from urllib.error import HTTPError
 from HTMLParser import HTMLParser
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -35,7 +35,7 @@ class DenDanskeOrdbogDownloader(AudioDownloader):
         if not field_data.word:
             return
         search_soup = self.get_soup_from_url(
-            self.url + urllib.urlencode(dict(query=field_data.word)))
+            self.url + urllib.parse.urlencode(dict(query=field_data.word)))
         search_results = search_soup.find(
             'div', {'class': 'searchResultBox'}).findAll('a')
         if search_results:

--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -13,7 +13,7 @@ Download pronunciations for Danish from Den Danske Ordbog
 
 import urllib.request, urllib.parse, urllib.error
 from urllib.error import HTTPError
-from HTMLParser import HTMLParser
+from html.parser import HTMLParser
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
 

--- a/downloadaudio/downloaders/downloader.py
+++ b/downloadaudio/downloaders/downloader.py
@@ -13,8 +13,7 @@ Class to download a files from a speaking dictionary or TTS service.
 
 
 import tempfile
-import urllib
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import urlparse
 from BeautifulSoup import BeautifulSoup as soup
 
@@ -114,10 +113,10 @@ class AudioDownloader(object):
         if not with_pyqt:
             self.site_icon = None
             return
-        page_request = urllib2.Request(self.icon_url)
+        page_request = urllib.request.Request(self.icon_url)
         if self.user_agent:
             page_request.add_header('User-agent', self.user_agent)
-        page_response = urllib2.urlopen(page_request)
+        page_response = urllib.request.urlopen(page_request)
         if 200 != page_response.code:
             self.get_favicon()
             return
@@ -131,11 +130,11 @@ class AudioDownloader(object):
         # The url may be absolute or relative.
         if not urlparse.urlsplit(icon_url).netloc:
             icon_url = urlparse.urljoin(
-                self.url, urllib.quote(icon_url.encode('utf-8')))
-        icon_request = urllib2.Request(icon_url)
+                self.url, urllib.parse.quote(icon_url.encode('utf-8')))
+        icon_request = urllib.request.Request(icon_url)
         if self.user_agent:
             icon_request.add_header('User-agent', self.user_agent)
-        icon_response = urllib2.urlopen(icon_request)
+        icon_response = urllib.request.urlopen(icon_request)
         if 200 != icon_response.code:
             self.site_icon = None
             return
@@ -161,10 +160,10 @@ class AudioDownloader(object):
             self.site_icon = None
             return
         ico_url = urlparse.urljoin(self.icon_url, "/favicon.ico")
-        ico_request = urllib2.Request(ico_url)
+        ico_request = urllib.request.Request(ico_url)
         if self.user_agent:
             ico_request.add_header('User-agent', self.user_agent)
-        ico_response = urllib2.urlopen(ico_request)
+        ico_response = urllib.request.urlopen(ico_request)
         if 200 != ico_response.code:
             self.site_icon = None
             return
@@ -189,15 +188,15 @@ class AudioDownloader(object):
             # 32-bit encoding (UTF-32?). Avoid that. (The whole things
             # is a bit curious, but there shouldn’t really be any harm
             # in this.)
-            request = urllib2.Request(url_in.encode('ascii'))
+            request = urllib.request.Request(url_in.encode('ascii'))
         except UnicodeDecodeError:
-            request = urllib2.Request(url_in)
+            request = urllib.request.Request(url_in)
         try:
             # dto. But i guess this is even less necessary.
             request.add_header('User-agent', self.user_agent.encode('ascii'))
         except UnicodeDecodeError:
             request.add_header('User-agent', self.user_agent)
-        response = urllib2.urlopen(request)
+        response = urllib.request.urlopen(request)
         if 200 != response.code:
             raise ValueError(str(response.code) + ': ' + response.msg)
         return response.read()

--- a/downloadaudio/downloaders/downloader.py
+++ b/downloadaudio/downloaders/downloader.py
@@ -15,7 +15,7 @@ Class to download a files from a speaking dictionary or TTS service.
 import tempfile
 import urllib.request, urllib.error, urllib.parse
 import urllib.parse
-from BeautifulSoup import BeautifulSoup as soup
+from bs4 import BeautifulSoup as soup
 
 # Make this work without PyQt
 with_pyqt = True
@@ -120,7 +120,7 @@ class AudioDownloader(object):
         if 200 != page_response.code:
             self.get_favicon()
             return
-        page_soup = soup(page_response)
+        page_soup = soup(page_response, 'html.parser')
         try:
             icon_url = page_soup.find(
                 name='link', attrs={'rel': 'icon'})['href']
@@ -207,7 +207,7 @@ class AudioDownloader(object):
 
         Wrapper helper function aronud self.get_data_from_url()
         """
-        return soup(self.get_data_from_url(url_in))
+        return soup(self.get_data_from_url(url_in), 'html.parser')
 
     def get_tempfile_from_url(self, url_in):
         """

--- a/downloadaudio/downloaders/downloader.py
+++ b/downloadaudio/downloaders/downloader.py
@@ -14,7 +14,7 @@ Class to download a files from a speaking dictionary or TTS service.
 
 import tempfile
 import urllib.request, urllib.error, urllib.parse
-import urlparse
+import urllib.parse
 from BeautifulSoup import BeautifulSoup as soup
 
 # Make this work without PyQt
@@ -128,8 +128,8 @@ class AudioDownloader(object):
             self.get_favicon()
             return
         # The url may be absolute or relative.
-        if not urlparse.urlsplit(icon_url).netloc:
-            icon_url = urlparse.urljoin(
+        if not urllib.parse.urlsplit(icon_url).netloc:
+            icon_url = urllib.parse.urljoin(
                 self.url, urllib.parse.quote(icon_url.encode('utf-8')))
         icon_request = urllib.request.Request(icon_url)
         if self.user_agent:
@@ -159,7 +159,7 @@ class AudioDownloader(object):
         if not with_pyqt:
             self.site_icon = None
             return
-        ico_url = urlparse.urljoin(self.icon_url, "/favicon.ico")
+        ico_url = urllib.parse.urljoin(self.icon_url, "/favicon.ico")
         ico_request = urllib.request.Request(ico_url)
         if self.user_agent:
             ico_request.add_header('User-agent', self.user_agent)

--- a/downloadaudio/downloaders/downloader.py
+++ b/downloadaudio/downloaders/downloader.py
@@ -21,8 +21,8 @@ from BeautifulSoup import BeautifulSoup as soup
 # Make this work without PyQt
 with_pyqt = True
 try:
-    from PyQt4.QtGui import QImage
-    from PyQt4.QtCore import QSize, Qt
+    from PyQt5.QtGui import QImage
+    from PyQt5.QtCore import QSize, Qt
 except ImportError:
     with_pyqt = False
 

--- a/downloadaudio/downloaders/downloader.py
+++ b/downloadaudio/downloaders/downloader.py
@@ -183,19 +183,8 @@ class AudioDownloader(object):
         the requests, checks that we got error code 200 and returns
         the raw data only when everything is OK.
         """
-        try:
-            # There have been reports that the request was send in a
-            # 32-bit encoding (UTF-32?). Avoid that. (The whole things
-            # is a bit curious, but there shouldn’t really be any harm
-            # in this.)
-            request = urllib.request.Request(url_in.encode('ascii'))
-        except UnicodeDecodeError:
-            request = urllib.request.Request(url_in)
-        try:
-            # dto. But i guess this is even less necessary.
-            request.add_header('User-agent', self.user_agent.encode('ascii'))
-        except UnicodeDecodeError:
-            request.add_header('User-agent', self.user_agent)
+        request = urllib.request.Request(url_in)
+        request.add_header('User-agent', self.user_agent)
         response = urllib.request.urlopen(request)
         if 200 != response.code:
             raise ValueError(str(response.code) + ': ' + response.msg)

--- a/downloadaudio/downloaders/duden.py
+++ b/downloadaudio/downloaders/duden.py
@@ -14,7 +14,7 @@ Download pronunciations from Duden.
 
 import re
 import unicodedata
-import urlparse
+import urllib.parse
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -83,5 +83,5 @@ class DudenDownloader(AudioDownloader):
         """Check if link looks """
         if title_key not in link['title']:
             return False
-        return urlparse.urlsplit(link['href']).netloc \
-            == urlparse.urlsplit(self.url).netloc
+        return urllib.parse.urlsplit(link['href']).netloc \
+            == urllib.parse.urlsplit(self.url).netloc

--- a/downloadaudio/downloaders/google_tts.py
+++ b/downloadaudio/downloaders/google_tts.py
@@ -11,7 +11,7 @@
 Download pronunciations from GoogleTTS
 """
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from anki.template import furigana
 
@@ -63,4 +63,4 @@ class GooglettsDownloader(AudioDownloader):
         u"""Return a string that can be used as the url."""
         qdict = dict(
             tl=self.language, q=source.encode('utf-8'), ie='utf-8', client='t')
-        return self.url + urllib.urlencode(qdict)
+        return self.url + urllib.parse.urlencode(qdict)

--- a/downloadaudio/downloaders/howjsay.py
+++ b/downloadaudio/downloaders/howjsay.py
@@ -11,7 +11,7 @@
 Download pronunciations from HowJSay.
 """
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -36,7 +36,7 @@ class HowJSayDownloader(AudioDownloader):
         # Replace special characters with ISO-8859-1 oct codes
         self.maybe_get_icon()
         word_path = self.get_tempfile_from_url(
-            self.url + urllib.quote(field_data.word.encode('utf-8')) +
+            self.url + urllib.parse.quote(field_data.word.encode('utf-8')) +
             self.file_extension)
         self.downloads_list.append(
             DownloadEntry(

--- a/downloadaudio/downloaders/islex.py
+++ b/downloadaudio/downloaders/islex.py
@@ -11,7 +11,7 @@
 Download pronunciations for Icelandic from islex.is
 """
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -41,7 +41,7 @@ class IslexDownloader(AudioDownloader):
         qdict = {'finna': 1, 'dict': 'SE', 'erflokin': 1, 'nlo': 1, 'fuzz': 1,
                  'samleit': field_data.word.encode('utf-8')}
         soup = self.get_soup_from_url(
-            self.url + 'se?' + urllib.urlencode(qdict))
+            self.url + 'se?' + urllib.parse.urlencode(qdict))
 
         if soup.findAll(attrs=dict(id='ord')):
             # When we have a table tag with id="ord" we (probably)

--- a/downloadaudio/downloaders/japanesepod.py
+++ b/downloadaudio/downloaders/japanesepod.py
@@ -17,7 +17,7 @@ from copy import copy
 import os
 import re
 import urllib.request, urllib.error, urllib.parse
-import urlparse
+import urllib.parse
 
 from ..blacklist import get_hash
 from ..download_entry import JpodDownloadEntry
@@ -152,7 +152,7 @@ class JapanesepodDownloader(AudioDownloader):
                     hits[audio] = popular
                     break
         for audio, popular in hits.items():
-            args = urlparse.parse_qs(audio.encode('utf-8'))
+            args = urllib.parse.parse_qs(audio.encode('utf-8'))
             audio_kanji = args['kanji'][0].decode('utf-8') \
                 if 'kanji' in args else None
             audio_kana = args['kana'][0].decode('utf-8') \

--- a/downloadaudio/downloaders/japanesepod.py
+++ b/downloadaudio/downloaders/japanesepod.py
@@ -16,8 +16,7 @@ from collections import OrderedDict
 from copy import copy
 import os
 import re
-import urllib
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import urlparse
 
 from ..blacklist import get_hash
@@ -118,12 +117,12 @@ class JapanesepodDownloader(AudioDownloader):
             qdict['kanji'] = kanji.encode('utf-8')
         if kana:
             qdict['kana'] = kana.encode('utf-8')
-        return self.url + urllib.urlencode(qdict)
+        return self.url + urllib.parse.urlencode(qdict)
 
     def get_words_from_wwwjdic(self):
         soup = self.get_soup_from_url(
             self.wwwjdic_url.format(
-                kana=urllib2.quote(self.field_data.kana.encode('utf-8'))))
+                kana=urllib.parse.quote(self.field_data.kana.encode('utf-8'))))
         # get 50 entries (no idea what the 2 means)
         labels = soup.findAll('label')
         hits = OrderedDict()
@@ -141,7 +140,7 @@ class JapanesepodDownloader(AudioDownloader):
             entry.extract()
             audio = re.search(r'm\("(.*)"\);', audio.text).group(1)
             # string is quoted twice, so unquote it once
-            audio = urllib2.unquote(audio)
+            audio = urllib.parse.unquote(audio)
             entry = entry.text
             popular = u'(P)' in entry or u'(P)' in lbl.text
             # strip "(P)" and similar markers

--- a/downloadaudio/downloaders/leo.py
+++ b/downloadaudio/downloaders/leo.py
@@ -98,11 +98,6 @@ class LeoDownloader(AudioDownloader):
                 matching_word = None
                 for el_word in side.findall('words/word'):
                     cur_word = el_word.text
-                    # Text in ElementTree has inconsistent types: "str" when it
-                    # contains only ASCII characters and "unicode" otherwise.
-                    # Make everything unicode.
-                    if type(cur_word) == str:
-                        cur_word = cur_word.decode('utf-8')
                     if self.normalize(cur_word) == self.normalize(
                             field_data.word):
                         matching_word = cur_word

--- a/downloadaudio/downloaders/leo.py
+++ b/downloadaudio/downloaders/leo.py
@@ -19,7 +19,7 @@ import xml.etree.ElementTree as ElementTree
 # Make this work without PyQt
 with_pyqt = True
 try:
-    from PyQt4.QtGui import QImage
+    from PyQt5.QtGui import QImage
 except ImportError:
     with_pyqt = False
 

--- a/downloadaudio/downloaders/leo.py
+++ b/downloadaudio/downloaders/leo.py
@@ -13,7 +13,7 @@ Download pronunciations from leo.org
 
 from collections import OrderedDict
 import re
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import xml.etree.ElementTree as ElementTree
 
 # Make this work without PyQt
@@ -80,7 +80,7 @@ class LeoDownloader(AudioDownloader):
         xml = self.get_data_from_url(
             self.dic_url.format(
                 lang=query_lang,
-                word=urllib.quote_plus(field_data.word.encode('utf-8')),
+                word=urllib.parse.quote_plus(field_data.word.encode('utf-8')),
                 direction=direction))
         root = ElementTree.fromstring(xml)
         hits = OrderedDict()

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -13,7 +13,7 @@ Download pronunciations from Lexin.
 """
 
 import unicodedata
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import json
 from BeautifulSoup import BeautifulSoup
 
@@ -75,11 +75,11 @@ class LexinDownloader(AudioDownloader):
             'se.jojoman.lexin.lexingwt.client.LookUpService|'
             'lookUpWord|se.jojoman.lexin.lexingwt.client.LookUpRequest/682723451|swe_swe|' +
             field_data.word.encode('utf-8') + '|1|2|3|4|1|5|5|1|6|1|7|')
-        request = urllib2.Request(
+        request = urllib.request.Request(
             self.url,
             payload, headers)
         try:
-            response = urllib2.urlopen(request)
+            response = urllib.request.urlopen(request)
         except:
             self.download_v1(field_data)
             return

--- a/downloadaudio/downloaders/lexin.py
+++ b/downloadaudio/downloaders/lexin.py
@@ -15,7 +15,7 @@ Download pronunciations from Lexin.
 import unicodedata
 import urllib.request, urllib.error, urllib.parse
 import json
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -91,7 +91,7 @@ class LexinDownloader(AudioDownloader):
         # inside the list.
         word_xmls = json.loads(data)[-3][3:-2]
         for word_xml in word_xmls:
-            soup = BeautifulSoup(word_xml)
+            soup = BeautifulSoup(word_xml, 'xml')
             extras = dict(Source='Lexin')
             try:
                 extras['Type'] = soup.find('lemma')['type']

--- a/downloadaudio/downloaders/macmillan.py
+++ b/downloadaudio/downloaders/macmillan.py
@@ -15,7 +15,7 @@ Abstract base class, derived for American and British English.
 
 from copy import copy
 import re
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -50,7 +50,7 @@ class MacmillanDownloader(AudioDownloader):
         self.maybe_get_icon()
         # Do our parsing with BeautifulSoup
         word_soup = self.get_soup_from_url(
-            self.url + urllib.quote(word.encode('utf-8')))
+            self.url + urllib.parse.quote(word.encode('utf-8')))
         # The audio clips are stored as images with class sound and
         # the link hidden in the onclick bit.
         sounds = word_soup.findAll(True, {'class': sound_class})

--- a/downloadaudio/downloaders/mw.py
+++ b/downloadaudio/downloaders/mw.py
@@ -11,7 +11,7 @@
 Download pronunciations from Merriam-Webster.
 """
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import re
 
 from .downloader import AudioDownloader
@@ -60,7 +60,7 @@ class MerriamWebsterDownloader(AudioDownloader):
             return
         # Do our parsing with BeautifulSoup
         word_soup = self.get_soup_from_url(
-            self.url + urllib.quote(field_data.word.encode('utf-8')))
+            self.url + urllib.parse.quote(field_data.word.encode('utf-8')))
         # The audio clips are stored as input tags with class au
         word_input_aus = word_soup.findAll(name='input', attrs={'class': 'au'})
         # The interesting bit it the onclick attribute and looks like
@@ -147,4 +147,4 @@ class MerriamWebsterDownloader(AudioDownloader):
     def get_popup_url(self, base_name, source):
         """Build url for the MW play audio pop-up."""
         qdict = dict(file=base_name, word=source)
-        return self.popup_url + urllib.urlencode(qdict)
+        return self.popup_url + urllib.parse.urlencode(qdict)

--- a/downloadaudio/downloaders/oald.py
+++ b/downloadaudio/downloaders/oald.py
@@ -14,7 +14,7 @@ Download pronunciations from  Oxford Advanced Learner’s Dictionary.
 
 from copy import copy
 import re
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from .downloader import AudioDownloader
 from ..download_entry import DownloadEntry
@@ -50,7 +50,7 @@ class OaldDownloader(AudioDownloader):
         self.maybe_get_icon()
         # Do our parsing with BeautifulSoup
         word_soup = self.get_soup_from_url(
-            self.url + urllib.quote(word.encode('utf-8')))
+            self.url + urllib.parse.quote(word.encode('utf-8')))
         self.ws = word_soup
         # The audio clips are stored as images with class sound and
         # the link hidden in the onclick bit.

--- a/downloadaudio/downloaders/wiktionary.py
+++ b/downloadaudio/downloaders/wiktionary.py
@@ -34,7 +34,6 @@ class WiktionaryDownloader(AudioDownloader):
         self.file_extension = u'.ogg'
         self.icon_url = 'http://de.wiktionary.org/'
         self.full_icon_url = 'http://bits.wikimedia.org/favicon/piece.ico'
-        self.url = 'http://{0}.wiktionary.org/wiki/{1}'
         # This re should find only the 'real' files, not the file
         # description pages. Mediawiki builds 256 (0x100) sub-folders
         # in the style <hex_digit_1>/<hex_digit_1><hex_digit_2>. Look
@@ -44,6 +43,16 @@ class WiktionaryDownloader(AudioDownloader):
         # This seems to work to extract the url from a <button> tag's
         # onclick attribute.
         self.button_onclick_re = '"videoUrl":"([^"]+)"'
+
+    @property
+    def url(self):
+        return 'http://%s.wiktionary.org/wiki/' % self.language
+
+    @url.setter
+    def url(self, value):
+        # Simply ignore assignment
+        # We need this because self.url is assigned on super().__init__
+        pass
 
     def download_files(self, field_data):
         """
@@ -57,8 +66,7 @@ class WiktionaryDownloader(AudioDownloader):
         u_word = urllib.parse.quote(field_data.word.encode('utf-8'))
         self.maybe_get_icon()
         self.language = self.language[:2]
-        word_soup = self.get_soup_from_url(
-            self.url.format(self.language, u_word))
+        word_soup = self.get_soup_from_url(self.url + u_word)
         # There are a number of ways the audio files can be present:
         ogg_url_list = []
         # As simple links:
@@ -105,8 +113,7 @@ class WiktionaryDownloader(AudioDownloader):
         for url_to_get in ogg_url_list:
             # We may have to add a scheme or a scheme and host
             # name (netloc). urlparse to the rescue!
-            word_url = urllib.parse.urljoin(
-                self.url.format(self.language, ''), url_to_get)
+            word_url = urllib.parse.urljoin(self.url, url_to_get)
             try:
                 word_path = self.get_tempfile_from_url(word_url)
             except:

--- a/downloadaudio/downloaders/wiktionary.py
+++ b/downloadaudio/downloaders/wiktionary.py
@@ -13,7 +13,7 @@ Download pronunciations from Wiktionary.
 
 import re
 import urllib.request, urllib.parse, urllib.error
-import urlparse
+import urllib.parse
 
 from .downloader import AudioDownloader, uniqify_list
 from ..download_entry import DownloadEntry
@@ -105,7 +105,7 @@ class WiktionaryDownloader(AudioDownloader):
         for url_to_get in ogg_url_list:
             # We may have to add a scheme or a scheme and host
             # name (netloc). urlparse to the rescue!
-            word_url = urlparse.urljoin(
+            word_url = urllib.parse.urljoin(
                 self.url.format(self.language, ''), url_to_get)
             try:
                 word_path = self.get_tempfile_from_url(word_url)

--- a/downloadaudio/downloaders/wiktionary.py
+++ b/downloadaudio/downloaders/wiktionary.py
@@ -21,8 +21,8 @@ from ..download_entry import DownloadEntry
 # Make this work without PyQt
 with_pyqt = True
 try:
-    from PyQt4.QtGui import QImage
-    from PyQt4.QtCore import QSize, Qt
+    from PyQt5.QtGui import QImage
+    from PyQt5.QtCore import QSize, Qt
 except ImportError:
     with_pyqt = False
 

--- a/downloadaudio/downloaders/wiktionary.py
+++ b/downloadaudio/downloaders/wiktionary.py
@@ -40,7 +40,7 @@ class WiktionaryDownloader(AudioDownloader):
         # in the style <hex_digit_1>/<hex_digit_1><hex_digit_2>. Look
         # for that pattern.
         self.word_ogg_re = \
-            ur'/([a-f0-9])/\1[a-f0-9]/[^/]*\b{word}\b[^/]*\.ogg$'
+            r'/([a-f0-9])/\1[a-f0-9]/[^/]*\b{word}\b[^/]*\.ogg$'
         # This seems to work to extract the url from a <button> tag's
         # onclick attribute.
         self.button_onclick_re = '"videoUrl":"([^"]+)"'

--- a/downloadaudio/downloaders/wiktionary.py
+++ b/downloadaudio/downloaders/wiktionary.py
@@ -12,7 +12,7 @@ Download pronunciations from Wiktionary.
 '''
 
 import re
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import urlparse
 
 from .downloader import AudioDownloader, uniqify_list
@@ -54,7 +54,7 @@ class WiktionaryDownloader(AudioDownloader):
             return
         if not field_data.word:
             return
-        u_word = urllib.quote(field_data.word.encode('utf-8'))
+        u_word = urllib.parse.quote(field_data.word.encode('utf-8'))
         self.maybe_get_icon()
         self.language = self.language[:2]
         word_soup = self.get_soup_from_url(

--- a/downloadaudio/get_fields.py
+++ b/downloadaudio/get_fields.py
@@ -44,7 +44,7 @@ split_kanji_kana = False
 # Replace ‘False’ with ‘True’ when you have no kanji in your reading field
 
 # Change this at your own risk.
-field_name_re = ur'{{(?:[/^#]|[^:}]+:|)([^:}{]*%s[^:}{]*)}}'
+field_name_re = r'{{(?:[/^#]|[^:}]+:|)([^:}{]*%s[^:}{]*)}}'
 
 
 def uniqify_list(seq):
@@ -112,7 +112,7 @@ def field_data(note, audio_field, reading=False):
             # While a bit tricky, this is not THAT hard to do. (Not
             # lookbehind needed.)
             sources_list = [
-                re.sub(ur'[\s_]{0}|{0}[\s_]?'.format(re.escape(afk)),
+                re.sub(r'[\s_]{0}|{0}[\s_]?'.format(re.escape(afk)),
                        '', a_name, count=1, flags=re.UNICODE)]
         for cnd in sources_list:
             for idx, lname in enumerate(f_names):

--- a/downloadaudio/mediafile_utils.py
+++ b/downloadaudio/mediafile_utils.py
@@ -32,7 +32,7 @@ def free_media_name(base, end):
     """
     base = stripHTML(base)
     # Strip the ‘invalidFilenameChars’ by hand.
-    base = re.sub(ur'[\\/:\*?\'"<>\|]', '', base)
+    base = re.sub(r'[\\/:\*?\'"<>\|]', '', base)
     base = unicodedata.normalize('NFC', base)
     # Looks like the normalization issue has finally been
     # solved. Always use NFC versions of file names now.

--- a/downloadaudio/review_gui.py
+++ b/downloadaudio/review_gui.py
@@ -24,7 +24,6 @@ import os
 from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtWidgets import QButtonGroup, QDialog, QDialogButtonBox, QFrame, \
     QGridLayout, QLabel, QPushButton, QScrollArea, QSizePolicy, QVBoxLayout
-from PyQt5.QtCore import SIGNAL, SLOT
 
 from aqt import mw
 from anki.lang import _
@@ -181,10 +180,8 @@ that they are sorry, will add this soon &c., click on this.""")
         dialog_buttons = QDialogButtonBox(self)
         dialog_buttons.addButton(QDialogButtonBox.Cancel)
         dialog_buttons.addButton(QDialogButtonBox.Ok)
-        self.connect(
-            dialog_buttons, SIGNAL("accepted()"), self, SLOT("accept()"))
-        self.connect(
-            dialog_buttons, SIGNAL("rejected()"), self, SLOT("reject()"))
+        dialog_buttons.accepted.connect(self.accept)
+        dialog_buttons.rejected.connect(self.reject)
         outer_layout.addWidget(dialog_buttons)
 
     def create_rows(self, layout, sarea):

--- a/downloadaudio/review_gui.py
+++ b/downloadaudio/review_gui.py
@@ -21,10 +21,10 @@ choices what to do wit each:
 
 import os
 
-from PyQt4.QtGui import QButtonGroup, QDialog, QDialogButtonBox, QFrame, \
-    QGridLayout, QIcon, QLabel, QPixmap, QPushButton, QScrollArea, \
-    QSizePolicy, QVBoxLayout
-from PyQt4.QtCore import SIGNAL, SLOT
+from PyQt5.QtGui import QIcon, QPixmap
+from PyQt5.QtWidgets import QButtonGroup, QDialog, QDialogButtonBox, QFrame, \
+    QGridLayout, QLabel, QPushButton, QScrollArea, QSizePolicy, QVBoxLayout
+from PyQt5.QtCore import SIGNAL, SLOT
 
 from aqt import mw
 from anki.lang import _

--- a/downloadaudio/update_gui.py
+++ b/downloadaudio/update_gui.py
@@ -9,7 +9,6 @@
 Change the download audio parameters on user input.
 """
 
-from PyQt5.QtCore import SIGNAL, SLOT
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QFrame, QGridLayout, \
     QHBoxLayout, QLabel, QLineEdit, QVBoxLayout
@@ -110,10 +109,8 @@ reading (ruby) on the right.</p>
         dialog_buttons = QDialogButtonBox(self)
         dialog_buttons.addButton(QDialogButtonBox.Cancel)
         dialog_buttons.addButton(QDialogButtonBox.Ok)
-        self.connect(dialog_buttons, SIGNAL("accepted()"),
-                     self, SLOT("accept()"))
-        self.connect(dialog_buttons, SIGNAL("rejected()"),
-                     self, SLOT("reject()"))
+        dialog_buttons.accepted.connect(self.accept)
+        dialog_buttons.rejected.connect(self.reject)
         layout.addWidget(dialog_buttons)
 
     def create_data_rows(self, layout):

--- a/downloadaudio/update_gui.py
+++ b/downloadaudio/update_gui.py
@@ -9,9 +9,10 @@
 Change the download audio parameters on user input.
 """
 
-from PyQt4.QtCore import SIGNAL, SLOT
-from PyQt4.QtGui import QDialog, QDialogButtonBox, QFrame, QGridLayout, \
-    QHBoxLayout, QIcon, QLabel, QLineEdit, QVBoxLayout
+from PyQt5.QtCore import SIGNAL, SLOT
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QFrame, QGridLayout, \
+    QHBoxLayout, QLabel, QLineEdit, QVBoxLayout
 
 from anki.lang import _
 

--- a/fix_negative_review_times.py
+++ b/fix_negative_review_times.py
@@ -15,8 +15,8 @@ the methods described in
 http://code.google.com/p/ankidroid/issues/detail?id=1449#c23
 """
 
-from PyQt4.QtCore import SIGNAL
-from PyQt4.QtGui import QAction
+from PyQt5.QtCore import SIGNAL
+from PyQt5.QtWidgets import QAction
 
 from anki.lang import _
 from aqt import mw

--- a/furikanji.py
+++ b/furikanji.py
@@ -44,18 +44,18 @@ else:
     # Pretty much what this is about. Use unicode word characters in
     # the pattern. Also name the groups so the code below becomes a
     # bit more readable.
-    split_pat = ur' ?(?P<kanji>\w+?)\[(?P<kana>.+?)\]'
+    split_pat = r' ?(?P<kanji>\w+?)\[(?P<kana>.+?)\]'
     # Add flag parameter to calls to re.sub.
     re_sub_flag = lambda pattern, repl, string: \
         re.sub(pattern, repl, string, flags=re.UNICODE)
 
-furigana_pat = ur'<ruby class="furigana"><rb>\g<kanji></rb>' + \
-               ur'<rt>\g<kana></rt></ruby>'
+furigana_pat = r'<ruby class="furigana"><rb>\g<kanji></rb>' + \
+               r'<rt>\g<kana></rt></ruby>'
 # The pattern to produce the furigana. What is called ruby in the old
 # code, but using named groups and adding a class.
 
 furikanji_pat = \
-    ur'<ruby class="furikanji"><rb>\g<kana></rb><rt>\g<kanji></rt></ruby>'
+    r'<ruby class="furikanji"><rb>\g<kana></rb><rt>\g<kanji></rt></ruby>'
 # Pattern to produce the furikanji.  This is pretty much the reason
 # for this add-on.
 
@@ -78,13 +78,13 @@ def no_sound(repl):
 def kanji_word_re(txt, *dummy_args):
     """Strip kana and wrap base text in class kanji."""
     return re_sub_flag(
-        split_pat, no_sound(ur'<span class="kanji">\g<kanji></span>'), txt)
+        split_pat, no_sound(r'<span class="kanji">\g<kanji></span>'), txt)
 
 
 def kana_word_re(txt, *dummy_args):
     """Strip base text and wrap kana in class kana."""
     return re_sub_flag(
-        split_pat, no_sound(ur'<span class="kana">\g<kana></span>'), txt)
+        split_pat, no_sound(r'<span class="kana">\g<kana></span>'), txt)
 
 
 def furigana_word_re(txt, *dummy_args):

--- a/kanjitips/tips.py
+++ b/kanjitips/tips.py
@@ -108,7 +108,7 @@ current_script = u''
 # debug: rememeber:
 #pp(mw.reviewer.web.page().mainFrame().toHtml())
 
-skip_re = ur"\[(:?sound|type):(:?.*?)\]"
+skip_re = r"\[(:?sound|type):(:?.*?)\]"
 
 
 def uniqify_list(seq):

--- a/lean_browser_qa.py
+++ b/lean_browser_qa.py
@@ -7,7 +7,7 @@
 u"""Anki-2 add-on to hide text in the card browser. """
 
 import re
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 from aqt.browser import DataModel
 
 __version__ = "1.0.1"
@@ -18,7 +18,7 @@ hide_class_name = u'browserhide'
 
 def reduce_format_qa(self, text):
     u"""Remove elements with a given class before displaying."""
-    soup = BeautifulSoup(text)
+    soup = BeautifulSoup(text, 'html.parser')
     for hide in soup.findAll(True, {'class': re.compile(
                 '\\b' + hide_class_name + '\\b')}):
         hide.extract()

--- a/local_css_and_diy_night_mode.py
+++ b/local_css_and_diy_night_mode.py
@@ -15,8 +15,8 @@ Load the file 'user_style.css' from the user’s profile folder
 the style from the template.
 """
 
-from PyQt4.QtGui import QAction, QActionGroup, QMenu
-from PyQt4.QtCore import SIGNAL
+from PyQt5.QtWidgets import QAction, QActionGroup, QMenu
+from PyQt5.QtCore import SIGNAL
 
 import os
 import re

--- a/local_css_and_diy_night_mode.py
+++ b/local_css_and_diy_night_mode.py
@@ -59,10 +59,10 @@ def fix_body_class():
         template_nr = mw.reviewer.card.ord
     else:
         template_nr = 0
-    template_class = re.sub(ur'[\W_]+', u'',
+    template_class = re.sub(r'[\W_]+', u'',
                             model['tmpls'][template_nr]['name']).lower()
-    model_class = re.sub(ur'[\W_]+', u'', model['name']).lower()
-    body_class = ur'{0} card card{1} template_{2} model_{3}'.format(
+    model_class = re.sub(r'[\W_]+', u'', model['name']).lower()
+    body_class = r'{0} card card{1} template_{2} model_{3}'.format(
         local_class, mw.reviewer.card.ord + 1,
         template_class, model_class)
     try:

--- a/mhwave.py
+++ b/mhwave.py
@@ -5,8 +5,9 @@
 # http://www.gnu.org/copyleft/gpl.html
 u"""Anki 2 add-on that opens an audio editor."""
 
-from PyQt4.QtCore import SIGNAL
-from PyQt4.QtGui import QAction, QIcon, QMenu
+from PyQt5.QtCore import SIGNAL
+from PyQt5.QtGui import QIcon
+from PyQt5.QtWidgets import QAction, QMenu
 import copy
 import os
 import re

--- a/mhwave.py
+++ b/mhwave.py
@@ -20,7 +20,7 @@ from aqt.editor import Editor
 
 __version__ = "2.0.0"
 
-sound_re = ur'\[sound:(.*?)\]'
+sound_re = r'\[sound:(.*?)\]'
 
 command_list = ['mhwaveedit']
 sound_ending_list = ['.mp3', '.wav', '.flac', '.ogg']

--- a/more_shortcuts.py
+++ b/more_shortcuts.py
@@ -19,8 +19,8 @@ on a Dvorak keyboard (See also my “Dvorak keys” add-on.) or with the
 right hand on the numeric key-pad.
 """
 
-from PyQt4.QtCore import SIGNAL
-from PyQt4.QtGui import QKeySequence, QShortcut
+from PyQt5.QtCore import SIGNAL
+from PyQt5.QtGui import QKeySequence, QShortcut
 
 from anki.hooks import wrap
 from aqt import mw

--- a/nachschlagen.py
+++ b/nachschlagen.py
@@ -13,8 +13,12 @@ u"""Add a menu to Anki2 to look up words in a few more dictionaries. """
 
 
 import urllib
+from PyQt5.QtCore import QUrl
+from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtWidgets import QAction, QMenu
+
 from aqt import mw
-from aqt.qt import QDesktopServices, QUrl, QMenu, QAction, SIGNAL
+from aqt.qt import SIGNAL
 from aqt.utils import tooltip
 from aqt.webview import QWebPage
 

--- a/play_button.py
+++ b/play_button.py
@@ -25,7 +25,7 @@ from aqt.reviewer import Reviewer
 
 __version__ = "1.5.0"
 
-sound_re = ur"\[sound:(.*?)\]"
+sound_re = r"\[sound:(.*?)\]"
 
 original_arrow_name = 'replay.png'
 collection_arrow_name = '_inline_replay_button.png'

--- a/play_button.py
+++ b/play_button.py
@@ -11,7 +11,7 @@ import os
 import re
 import shutil
 
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 
@@ -92,7 +92,7 @@ def add_preview_link_handler(browser):
 
 def reduce_format_qa(self, text):
     u"""Remove elements with a given class before displaying."""
-    soup = BeautifulSoup(text)
+    soup = BeautifulSoup(text, 'html.parser')
     for hide in soup.findAll(True, {'class': re.compile(
             '\\b' + hide_class_name + '\\b')}):
         hide.extract()

--- a/quick_note_and_deck_buttons.py
+++ b/quick_note_and_deck_buttons.py
@@ -90,8 +90,8 @@ deck_buttons = [
 ## IAR, (or "practicality beats purity"). Put the stuff to change on
 ## top, even before the imports.
 
-from PyQt4.QtCore import SIGNAL
-from PyQt4.QtGui import QHBoxLayout, QKeySequence, QPushButton, QShortcut
+from PyQt5.QtCore import SIGNAL
+from PyQt5.QtGui import QHBoxLayout, QKeySequence, QPushButton, QShortcut
 
 from aqt.modelchooser import ModelChooser
 from aqt.deckchooser import DeckChooser

--- a/quick_replay.py
+++ b/quick_replay.py
@@ -25,7 +25,7 @@ if isWin:
     subprocess.STARTUPINFO.wShowWindow = subprocess.SW_HIDE
     subprocess.STARTUPINFO.dwFlags = subprocess.STARTF_USESHOWWINDOW
 
-sound_re = ur'\[sound:(.*?)\]'
+sound_re = r'\[sound:(.*?)\]'
 
 command_list = ['mplayer', '-really-quiet']
 if isWin:

--- a/spanify.py
+++ b/spanify.py
@@ -24,7 +24,7 @@ __version__ = "2.1.0"
 def add_span(editor, s_class):
     u"""Call js function to wrap text in the span."""
     editor.web.eval(
-        ur"""wrap('<span class=\"{cls}\">', '</span>');""".format(
+        r"""wrap('<span class=\"{cls}\">', '</span>');""".format(
             cls=s_class))
 
 

--- a/svg_play_button.py
+++ b/svg_play_button.py
@@ -26,7 +26,7 @@ from aqt.reviewer import Reviewer
 
 __version__ = "1.0.0"
 
-sound_re = ur"\[sound:(.*?)\]"
+sound_re = r"\[sound:(.*?)\]"
 
 hide_class_name = u'browserhide'
 

--- a/svg_play_button.py
+++ b/svg_play_button.py
@@ -11,7 +11,7 @@ import os
 import re
 import shutil
 
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 
@@ -112,9 +112,9 @@ def add_preview_link_handler(browser):
 
 def reduce_format_qa(self, text):
     u"""Remove elements with a given class before displaying."""
-    soup = BeautifulSoup(text)
+    soup = BeautifulSoup(text, 'html.parser')
     for hide in soup.findAll(True, {'class': re.compile(
-            '\\b' + hide_class_name + '\\b')}):
+        '\\b' + hide_class_name + '\\b')}):
         hide.extract()
     return original_format_qa(self, unicode(soup))
 

--- a/svg_play_button.py
+++ b/svg_play_button.py
@@ -12,8 +12,8 @@ import re
 import shutil
 
 from BeautifulSoup import BeautifulSoup
-from PyQt4.QtCore import QUrl
-from PyQt4.QtGui import QDesktopServices
+from PyQt5.QtCore import QUrl
+from PyQt5.QtGui import QDesktopServices
 
 from anki.cards import Card
 from anki.hooks import addHook, wrap

--- a/unnormalize.py
+++ b/unnormalize.py
@@ -19,7 +19,7 @@ import sys
 import unicodedata
 
 from PyQt4.QtCore import QCoreApplication, SIGNAL
-from PyQt4.QtGui import QAction, QProgressDialog
+from PyQt5.QtWidgets import QAction, QProgressDialog
 
 from anki.utils import isMac
 from anki.lang import _

--- a/zoom.py
+++ b/zoom.py
@@ -5,8 +5,9 @@
 
 """Add-on for Anki 2 to zoom in or out."""
 
-from PyQt4.QtCore import Qt, SIGNAL
-from PyQt4.QtGui import QAction, QKeySequence, QMenu
+from PyQt5.QtCore import Qt, SIGNAL
+from PyQt5.QtGui import QKeySequence
+from PyQt5.QtWidgets import QAction, QMenu
 
 from aqt import mw
 from anki.hooks import addHook, runHook, wrap


### PR DESCRIPTION
### What I did

I completely port the Download Audio add-on until I couldn't find any bug.

I did not test other add-ons, but incidentally made these broad changes to all codebase:
* some porting from PyQt4 to PyQt5
* some `2to3` fixes
* porting to BeautfulSoup 4 (the version used by Anki)

I used these references as guides:
* http://pyqt.sourceforge.net/Docs/PyQt5/pyqt4_differences.html
* the main porting commit from Anki itself: https://github.com/dae/anki/commit/de7e4

Please note that I do not know PyQt and this is the first time I see Anki's or this repo's source, so mistakes are expected. I tried my best though, to make at least downloadaudio work.

### Points I suggest you revise

* The uses of `BeautifulSoup` constructor, especially the occurences of `BeautifulSoup(text, 'html.parser')`. Maybe they should use another parser.
* Some suppressions I made of encoding/decoding strings. I removed only parts which where causing bugs by changed semantics on python 3
