### PR TITLE
Fixed Searching words with Danish characters at DDO #97

### DIFF
--- a/downloadaudio/downloaders/den_danske_ordbog.py
+++ b/downloadaudio/downloaders/den_danske_ordbog.py
@@ -35,7 +35,7 @@ class DenDanskeOrdbogDownloader(AudioDownloader):
         if not field_data.word:
             return
         search_soup = self.get_soup_from_url(
-            self.url + urllib.urlencode(dict(query=field_data.word)))
+            self.url + urllib.urlencode(dict(query=field_data.word.encode('utf-8'))))
         search_results = search_soup.find(
             'div', {'class': 'searchResultBox'}).findAll('a')
         if search_results:


### PR DESCRIPTION
Fixed encoding error for special characters when searching in Den Danske Ordbog (æ, ø or å)