### PR TITLE
Fix #102 by switching AddCards model without running hook

### DIFF
--- a/quick_note_and_deck_buttons.py
+++ b/quick_note_and_deck_buttons.py
@@ -116,6 +116,7 @@ from aqt.qt import *
 
 from aqt.modelchooser import ModelChooser
 from aqt.deckchooser import DeckChooser
+from aqt.addcards import AddCards
 from aqt.utils import tooltip
 
 from anki.hooks import wrap
@@ -197,7 +198,13 @@ def change_model_to(chooser, model_name):
     cdeck = chooser.deck.decks.current()
     cdeck['mid'] = m['id']
     chooser.deck.decks.save(cdeck)
-    runHook("currentModelChanged")
+    window = chooser.widget.parent()
+    if window and isinstance(window, AddCards):
+        # Workaround for "Multiple Windows" add-on:
+        window.onModelChange()
+        chooser.onReset()
+    else:
+        runHook("currentModelChanged")
     chooser.mw.reset()
 
 


### PR DESCRIPTION
This is a workaround, more than anything, but it does fix #102.

The underlying issue was that the author of the "Multiple Add and Browser Windows" add-on decided to remove several global hooks surrounding note type switching in order to allow setting different note types for different AddCards instances. This had the unfortunate side-effect of stopping the note type buttons from working.

I've tested this change both with and without the other add-on. The buttons work as expected in both cases with no change in functionality.