### PR TITLE
Port Add note id to Anki 2.1

### DIFF
--- a/add_note_id.py
+++ b/add_note_id.py
@@ -1,6 +1,7 @@
 # -*- mode: Python ; coding: utf-8 -*-
 #
 # Copyricht © 2012 Roland Sieker, <ospalh@gmail.com>
+# Copyright © 2017 Luo Li-Yan, <joseph.lorimer13@gmail.com>
 #
 # Portions of this file were originally written by
 # Damien Elmes <anki@ichi2.net>
@@ -22,9 +23,10 @@ from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import QAction, QProgressDialog
 
 
-from anki.hooks import addHook
+from anki.hooks import addHook, wrap
 from anki.lang import _
 from aqt import mw
+from aqt.editor import Editor
 from aqt.utils import askUser
 
 __version__ = '1.2.1'
@@ -123,10 +125,19 @@ def onFocusLost(flag, n, fidx):
     return True
 
 
+def onLoadNote(self, *args, **kwargs):
+    for f in self.note.keys():
+        if f.lower() in id_fields and not self.note[f]:
+            self.note[f] = str(self.note.id - int(13e11))
+
+
 if show_menu_item:
     add_nid = QAction(mw)
     mw.form.menuTools.addAction(add_nid)
     add_nid.setText(_(u"Add note ids"))
     add_nid.triggered.connect(add_nids_to_all)
 
+
 addHook('editFocusLost', onFocusLost)
+
+Editor.loadNote = wrap(Editor.loadNote, onLoadNote, 'before')

--- a/add_note_id.py
+++ b/add_note_id.py
@@ -18,7 +18,7 @@ Anki2 add-on to make notes unique
 Add the note id to a field named Note ID in
 """
 
-from PyQt5.QtCore import QCoreApplication, SIGNAL
+from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import QAction, QProgressDialog
 
 
@@ -92,7 +92,7 @@ def add_nids_to_all():
                 if f == name.lower():
                     # Check if target is empty
                     if not n[name]:
-                        n[name] = str(nid - long(13e11))
+                        n[name] = str(nid - int(13e11))
                         n.flush()
     mw.reset()
 
@@ -119,7 +119,7 @@ def onFocusLost(flag, n, fidx):
     if field_index != fidx:
         return flag
     # Got to here: We have an empty id field, so put in a number.
-    n[field_name] = str(n.id - long(13e11))
+    n[field_name] = str(n.id - int(13e11))
     return True
 
 
@@ -127,6 +127,6 @@ if show_menu_item:
     add_nid = QAction(mw)
     mw.form.menuTools.addAction(add_nid)
     add_nid.setText(_(u"Add note ids"))
-    mw.connect(add_nid, SIGNAL("triggered()"), add_nids_to_all)
+    add_nid.triggered.connect(add_nids_to_all)
 
 addHook('editFocusLost', onFocusLost)


### PR DESCRIPTION
This pull request fixes the obvious Python 2/Qt4 -> Python 3/Qt5 issues. It also adds a second hook to make sure the Note ID field is filled automatically when the note loads. See discussion here: https://anki.tenderapp.com/discussions/add-ons/14498-porting-an-add-on-from-20-to-21