### PR TITLE
Make sure to return from original link handler to preserve Python → JS bridge

### DIFF
--- a/play_button/__init__.py
+++ b/play_button/__init__.py
@@ -100,7 +100,7 @@ def review_link_handler_wrapper(reviewer, url):
     if url.startswith("ankiplay"):
         play(url[8:])
     else:
-        original_review_link_handler(reviewer, url)
+        return original_review_link_handler(reviewer, url)
 
 
 def simple_link_handler(url):


### PR DESCRIPTION
Hi ospalh,

I've been trying to resolve common add-on conflicts recently, and one of the key issues I've found were problems with the implementation of link handler patches. The crux is that in Anki 2.1, the link handler no longer only acts as a one-way street between JS and Python, but can also pass return values from Python to JS via an optional `pycmd` callback (cf. https://github.com/dae/anki/pull/228 and https://github.com/dae/anki/commit/56e1643bfa0391c71d3323b7d12b77c9fa8af551).

Unfortunately this is not as obvious in Anki's source code as it probably should be (something I plan to file a PR for), and expectedly many add-ons do not return from their custom link handlers. As a result they interfere with other add-ons that do depend on this Python → JS bridge (e.g. Pop-up Dictionary).

So what I'm trying to do at the moment is to go through the add-ons in question and either file PRs to fix the problem, or notify the authors about the situation. Since I likely won't be able to catch all cases, I'd very much appreciate it if you could check and see if you can find any other add-ons that have the same problem.

Thanks a lot in advance!