### PR TITLE
Minor python3 fix for downloadaudio

### DIFF
--- a/downloadaudio/blacklist.py
+++ b/downloadaudio/blacklist.py
@@ -37,7 +37,7 @@ def get_hash(file_name):
     """
     if not blacklist_hashes:
         load_hashes()
-    retrieved_hash = hashlib.sha256(file(file_name, 'rb').read())
+    retrieved_hash = hashlib.sha256(open(file_name, 'rb').read())
     if retrieved_hash.hexdigest() in blacklist_hashes:
         raise ValueError(
             'Retrieved file is in blacklist. (No pronunciation found.)')


### PR DESCRIPTION
Use 'open' to open a file rather than 'file'.

Note that for this to be useful I also had to use the changes in https://github.com/ospalh/anki-addons/pull/119. With that change alone, however, the menus all work but it always results in "Nothing downloaded".  This was due to an exception happening here (and being caught elsewhere along with 404's etc).